### PR TITLE
Pass fixed values to update database when using form validation

### DIFF
--- a/z_response.php
+++ b/z_response.php
@@ -653,7 +653,7 @@
             // Gather all fields from the form
             foreach($validationResult->fields as $field) {
                 if($field->noSave) continue;
-                if($field->dbField == $pkField) continue;
+                if($field->dbField == $pkField && $field->value == $pkValue) continue;
 
                 $fields[] = $field->dbField;
                 $values[] = $field->value;
@@ -662,6 +662,8 @@
 
             // Gather fixed values
             foreach($fixed as $field => $value) {
+                if($field == $pkField && $value == $pkValue) continue;
+
                 $fields[] = $field;
                 $values[] = $value;
                 $types .= "s";

--- a/z_response.php
+++ b/z_response.php
@@ -628,7 +628,7 @@
             $sql = "SELECT `$pkField` FROM `$table` WHERE `$pkField`=?";
             $db->exec($sql, $pkType, $pkValue);
             if($db->countResults() > 0) {
-                $this->updateDatabase($table, $pkField, $pkType, $pkValue, $validationResult);
+                $this->updateDatabase($table, $pkField, $pkType, $pkValue, $validationResult, $fixed);
                 return $pkValue;
             }
             return $this->insertDatabase($table, $validationResult, $fixed);
@@ -642,39 +642,39 @@
          * @param string $pkValue Value of the primary key in the row to change
          * @param FormResult $validationResult Result of the validation
          */
-        public function updateDatabase(string $table, string $pkField, string $pkType, $pkValue, FormResult $validationResult) {
+        public function updateDatabase(string $table, string $pkField, string $pkType, $pkValue, FormResult $validationResult, array $fixed = []) {
             //First check for file uploads
             $this->uploadFromForm($validationResult);
 
-            $db = $this->booter->z_db;
-            $vals = [];
-            $sql = "UPDATE `$table` SET";
-            $types = "";            
+            $fields = [];
+            $values = [];
+            $types = "";
 
-            for ($i = 0; $i < count($validationResult->fields) - 1; $i++) {
-                $field = $validationResult->fields[$i];
+            // Gather all fields from the form
+            foreach($validationResult->fields as $field) {
+                if($field->noSave) continue;
 
-                if ($field->noSave) {
-                    continue;
-                }
-
-                $sql .= " `". $field->dbField . "` = ?, ";
+                $fields[] = $field->dbField;
+                $values[] = $field->value;
                 $types .= $field->dataType;
-                $vals[] = $field->value;
             }
 
-            //TODO: Implement $field->noSave for last part of the query
+            // Gather fixed values
+            foreach($fixed as $field => $value) {
+                $fields[] = $field;
+                $values[] = $value;
+                $types .= "s";
+            }
 
-            $field = $validationResult->fields[$i];
-            $sql .= " `". $field->dbField . "` = ?";
-            $types .= $field->dataType;
-            $vals[] = $field->value;
-            
-            $sql .= " WHERE `$pkField` = ?;";
-            $types .= $pkType;
-            $vals[] = $pkValue;
+            // Build the query
+            $sql = "UPDATE `$table` SET";
+            $sql .= " `".implode("`=?,`", $fields)."`=? ";
 
-            $db->exec($sql, $types, ...$vals);
+            // Filtering condition
+            $sql .= "WHERE `$pkField` = ?;";
+            $values[] = $pkValue;
+
+            $this->booter->z_db->exec($sql, $types.$pkType, ...$values);
         }
 
         /**

--- a/z_response.php
+++ b/z_response.php
@@ -653,6 +653,7 @@
             // Gather all fields from the form
             foreach($validationResult->fields as $field) {
                 if($field->noSave) continue;
+                if($field->dbField == $pkField) continue;
 
                 $fields[] = $field->dbField;
                 $values[] = $field->value;


### PR DESCRIPTION
Fixes  #9

Fixed values are not supported when updating based on a form result, `insertOrUpdate` however allows for fixed values, which are then only set on insert and never updated again.

### Unintended Behavior:
The following is an example from an existing project, showing that this behavior was not intended and simply forgotten when implementing `insertOrUpdate`:
```PHP
// Save the source on creation of an account for the first time
if(!isset($account)) $fixedValues["source"] = $source;

$accountId = $res->insertOrUpdateDatabase(
    "account", "userId", "i",
    $userId, $formResult, $fixedValues,
);
```

### Testcase
Before:
```SQL
UPDATE `company_landingpage` SET `aaa` = ?, `bbb` = ?, `ccc` = ? WHERE `id` = ?;
```

After:
```SQL
UPDATE `company_landingpage` SET `aaa`=?,`bbb`=?,`ccc`=?,`id`=?,`test_fixed`=? WHERE `id` = ?;
```