### PR TITLE
➕ Add PHPMailer as a direct dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
         "php": ">=8.0",
         "zubzet/password-hash-utilities": "1.0.*",
         "slim/slim": "^4.14",
-        "slim/psr7": "^1.7"
+        "slim/psr7": "^1.7",
+        "phpmailer/phpmailer": "^6.7"
     },
     "autoload": {
         "classmap": [


### PR DESCRIPTION
Move out the PHP Mailer dependency from user space to the framework. It will likely be moved into it's own module later.