### PR TITLE
refactor(routing): remove unnecessary fallbacksystem

### DIFF
--- a/src/Routing/PendingRoute.php
+++ b/src/Routing/PendingRoute.php
@@ -11,19 +11,6 @@ class PendingRoute extends PendingRoutingState {
     ) {}
 
     public function __destruct() {
-        if(str_ends_with($this->endpoint, '/*')) {
-            $this->endpoint = substr_replace($this->endpoint, '{param:.*}', -1);
-
-            Route::performFallback(
-                $this->endpoint, 
-                $this->method, 
-                $this->action, 
-                $this->middleware,
-                $this->afterMiddleware
-            );
-            return;
-        }
-
         Route::performRoute(
             $this->method,
             $this->endpoint,

--- a/src/Routing/Route.php
+++ b/src/Routing/Route.php
@@ -32,12 +32,6 @@ class Route {
         private static array $prefixStack = [];
 
         /**
-         * Holds deferred fallback routes to be registered later.
-         * @var array[]
-         */
-        private static array $deferredFallbacks = [];
-
-        /**
          * Initializes the static Router.
          * This must be called once before loading route files.
          *
@@ -73,39 +67,6 @@ class Route {
 
         static function group(string $prefix, callable $callback): PendingGroup {
             return new PendingGroup($prefix, $callback);
-        }
-
-        static function performFallback(string $endpoint, string $method, array $action, array $middlewares, array $afterMiddleware): void {
-            $fullPrefix = implode('', self::$prefixStack);
-
-            // Saves the fallback details for later registration.
-            self::$deferredFallbacks[] = [
-                'method'   => 'get',
-                'prefix'   => $fullPrefix,
-                'endpoint' => $endpoint,
-                'action'   => $action,
-                'middlewares' => $middlewares,
-                'afterMiddleware' => $afterMiddleware
-            ];
-        }
-
-        public static function registerDeferredFallbacks(): void {
-            usort(self::$deferredFallbacks, function ($a, $b) {
-                $countA = substr_count($a['prefix'] . $a['endpoint'], '/');
-                $countB = substr_count($b['prefix'] . $b['endpoint'], '/');
-                return $countB <=> $countA; // Absteigend sortieren
-            });
-
-            foreach (self::$deferredFallbacks as $fallback) {
-                $fullPath = $fallback['prefix'] . $fallback['endpoint'];
-                self::performRoute(
-                    $fallback['method'],
-                    $fullPath,
-                    $fallback['action'],
-                    $fallback['middlewares'],
-                    $fallback['afterMiddleware']
-                );
-            }
         }
 
         /**


### PR DESCRIPTION
Slim already provides a fallback system, which made the new one redundant. 
Additionally, the custom fallback did not behave as intended.

Routes that were previously defined as fallback  (endpoints like ../*) must be migrated to Slim’s built-in fallback  system using the pattern "[/{params:.*}]".