### PR TITLE
Parse url null value being passed to trim

### DIFF
--- a/src/main.php
+++ b/src/main.php
@@ -197,12 +197,10 @@
          * Format: root/class/method/parameter/parameter/...
          */
         private function parseUrl() {
-            $path = parse_url($this->url, PHP_URL_PATH);
-            $path = ltrim($path, '/');
-            $path = rtrim($path, '/');
-            $this->rootDirectory = ltrim($this->rootDirectory, '/');
-            $this->rootDirectory = rtrim($this->rootDirectory, '/');
-            
+            $path = parse_url($this->url, PHP_URL_PATH) ?: "";
+            $path = trim($path, '/');
+            $this->rootDirectory = trim($this->rootDirectory, '/');
+
             $urlParts = $path !== "" ? explode("/", $path) : [];
 
             $this->rootDirectory = $this->rootDirectory !== "" ? explode("/", $this->rootDirectory) : [];


### PR DESCRIPTION
There are likely more places in which NULL is passed to internal functions. We need to have a closer look at that,