### PR TITLE
Lazy load database connection on first usage

### DIFF
--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -1,0 +1,148 @@
+<?php
+
+    namespace ZubZet\Framework\Database;
+
+    use Cake\Database\Driver\Mysql;
+    use Cake\Database\Connection as QueryBuilderConnection;
+
+    class Connection {
+
+        use Interaction;
+
+        public QueryBuilderConnection $cakePHPDatabase;
+        private \mysqli $conn;
+        private \mysqli_stmt $stmt;
+        public \z_framework $booter;
+
+        public int $lastConnect;
+        public int $lastHeartbeat;
+        public int $connectTimeout;
+
+        public function __construct(\z_framework &$booter) {
+            $this->booter = $booter;
+
+            $this->cakePHPDatabase = new QueryBuilderConnection([
+                'driver' => Mysql::class,
+            ]);
+
+            $this->connectTimeout = $booter->req->getBooterSettings(
+                "db_connection_timeout",
+                default: 900,
+            );
+        }
+
+        private function connect() {
+            // Make sure no previous connection exists
+            $this->disconnect();
+
+            // Connect to the database
+            $this->conn = new \mysqli(
+                $this->booter->dbhost,
+                $this->booter->dbusername,
+                $this->booter->dbpassword,
+                $this->booter->dbname,
+            );
+
+            // Set the connection charset
+            $this->conn->set_charset("utf8mb4");
+
+            // Remember the connection time
+            $this->lastConnect = time();
+        }
+
+        public function assertConnection() {
+            // No connection or connection lost
+            if(!isset($this->conn) || $this->conn->connect_errno) {
+                $this->connect();
+                return;
+            }
+
+            // Check if we need to reconnect due to timeout
+            if(!isset($this->lastConnect) || time() - $this->lastConnect >= $this->connectTimeout) {
+                if(!isset($this->lastHeartbeat) || time() - $this->lastHeartbeat >= $this->connectTimeout) {
+                    // Try a heartbeat to see if the connection is still alive
+                    $connectionAlive = false;
+                    try {
+                        $connectionAlive = $this->heartbeat(waitForTimeout: false);
+                    } catch(\Exception) {} finally {
+                        if(!$connectionAlive) $this->connect();
+                    }
+                }
+            }
+        }
+
+        /**
+         * Executes a query as prepared statement
+         * @param string $query Query written as prepared statement (that thing with the question marks as placeholders)
+         * @return Connection Returning this for chaining 
+         */
+        public function exec($query) {
+            // Make sure a connection was made
+            $this->assertConnection();
+
+            $args = func_get_args();
+            $this->stmt = $this->conn->prepare($query);
+
+            if(count($args) > 1) {
+                array_shift($args);
+                if (is_bool($this->stmt)) {
+                    throw new \Exception("SQL Error: " . $this->conn->error . "\nQuery: " . $query);
+                }
+                $this->stmt->bind_param(...$args);
+            }
+
+            if(is_bool($this->stmt)) {
+                throw new \Exception("SQL Error: " . $this->conn->error . "\nQuery: " . $query);
+            }
+            $this->stmt->execute();
+            $this->insertId = $this->conn->insert_id;
+
+            if($this->stmt->errno) {
+                throw new \Exception("SQL Error: " . $this->stmt->error . "\nQuery: " . $query);
+            }
+
+            $this->result = $this->stmt->get_result();
+            $this->stmt->close();
+
+            $this->lastHeartbeat = time();
+
+            return $this;
+        }
+
+        /**
+         * Run a very lightweight query to keep the connection alive
+         * @return bool Was the heartbeat successful
+         */
+        public function heartbeat($waitForTimeout = true, $timeoutBuffer = 30): bool {
+            if($waitForTimeout && isset($this->lastHeartbeat)) {
+                // Only ping if the timeout was reached
+                $timeSinceLastHeartbeat = time() - $this->lastHeartbeat;
+                if($timeSinceLastHeartbeat < max(1, $this->connectTimeout - $timeoutBuffer)) {
+                    return true;
+                }
+            }
+            $this->lastHeartbeat = time();
+            return $this->conn->ping();
+        }
+
+        /**
+         * Disconnect from the database
+         * @param boolean $forceClose Close the connection regardless of if it seems to be open
+         * @return void
+         */
+        public function disconnect() {
+            if(!isset($this->conn)) return;
+            $this->conn->close();
+        }
+
+        /**
+         * Closes the database connection on exit
+         */
+        public function __destruct() {
+            $this->disconnect();
+        }
+    }
+
+    class_alias(Connection::class, "z_db");
+
+?>

--- a/src/Database/Interaction.php
+++ b/src/Database/Interaction.php
@@ -1,187 +1,18 @@
 <?php
-    /**
-     * z_db is used as a proxy for all database actions
-     */
 
-    use Cake\Database\Driver\Mysql;
-    use Cake\Database\Connection;
+    namespace ZubZet\Framework\Database;
 
-    /**
-     * Proxy for all database access. Also holds utility functions
-     */
-    class z_db {
+    trait Interaction {
 
         /**
-         * @var Connection $cakePHPDatabase CakePHP Database connection for query builder usage
-         */
-        public Connection $cakePHPDatabase;
-        
-        /**
-         * @var mysqli $conn Connection to the database
-         */
-        private $conn;
-
-        /**
-         * @var mysqli_stmt $stmt Prepared statement object used for queries
-         */
-        private $stmt;
-
-        /**
-         * @var null|bool|mysqli_result $result Result of the last query
+         * @var null|bool|\mysqli_result $result Result of the last query
          */
         public $result;
-
-        /**
-         * @var z_framework $booter Reference to the booter
-         */
-        public $booter;
 
         /**
          * @var int $insertId Last insert id
          */
         public $insertId;
-
-        /**
-         * @var int $lastConnect Unix timestamp of the last database connect
-         */
-        public $lastConnect;
-
-        /**
-         * @var int $lastConnect Unix timestamp of the last database connect
-         */
-        public $lastHeartbeat;
-
-        /**
-         * @var int $connectTimeout Database connection timeout in seconds. Defaults to 0.5 hours
-         */
-        public int $connectTimeout;
-        
-        /**
-         * When instanced, a db connection is given as a refrence
-         */
-        public function __construct(&$booter) {
-            $this->cakePHPDatabase = new Connection([
-                'driver' => Mysql::class,
-            ]);
-
-            $this->booter = $booter;
-            $this->connectTimeout = $booter->req->getBooterSettings(
-                "db_connection_timeout",
-                $useDefault = true,
-                900,
-            );
-            $this->connect(firstConnection: true);
-        }
-
-        /**
-         * Closes the database connection on exit
-         */
-        public function __destruct() {
-            $this->disconnect();
-        }
-
-        /**
-         * Make a connection to the database
-         * @param string $charset
-         * @param bool $firstConnection Determine if this a reconnect
-         * @return void
-         */
-        public function connect($charset = "utf8mb4", $firstConnection = false) {
-            // Try to close the connection if it exists
-            if(!$firstConnection) {
-                $this->disconnect();
-            }
-
-            // Connect to the database
-            $this->conn = new mysqli(
-                $this->booter->dbhost,
-                $this->booter->dbusername,
-                $this->booter->dbpassword,
-                $this->booter->dbname
-            );
-
-            // Set the connection charset
-            $this->conn->set_charset($charset);
-
-            // Remember the connection time
-            $this->lastConnect = time();
-        }
-
-        public function assertConnection() {
-            try {
-                $this->heartbeat(waitForTimeout: false);
-            } catch(\Exception) {
-                $this->connect();
-            }
-        }
-
-        /**
-         * Disconnect from the database
-         * @param boolean $forceClose Close the connection regardless of if it seems to be open
-         * @return void
-         */
-        public function disconnect($forceClose = false) {
-            if($forceClose || $this->heartbeat()) {
-                $this->conn->close();
-            }
-        }
-
-        /**
-         * Executes a query as prepared statement
-         * @param string $query Query written as prepared statement (that thing with the question marks as placeholders)
-         * @return z_db Returning this for chaining 
-         */
-        public function exec($query) {
-            // Make sure a connection was made and has not timed out
-            if(!isset($this->lastConnect) || time() - $this->lastConnect >= $this->connectTimeout) {
-                if(!isset($this->lastHeartbeat) || time() - $this->lastHeartbeat >= $this->connectTimeout) {
-                    $this->assertConnection();
-                }
-            }
-
-            $args = func_get_args();
-            $this->stmt = $this->conn->prepare($query);
-
-            if(count($args) > 1) {
-                array_shift($args);
-                if (is_bool($this->stmt)) {
-                    throw new Exception("SQL Error: " . $this->conn->error . "\nQuery: " . $query);
-                }
-                $this->stmt->bind_param(...$args);
-            }
-
-            if(is_bool($this->stmt)) {
-                throw new Exception("SQL Error: " . $this->conn->error . "\nQuery: " . $query);
-            }
-            $this->stmt->execute();
-            $this->insertId = $this->conn->insert_id;
-
-            if($this->stmt->errno) {
-                throw new Exception("SQL Error: " . $this->stmt->error . "\nQuery: " . $query);
-            }
-
-            $this->result = $this->stmt->get_result();
-            $this->stmt->close();
-
-            $this->lastHeartbeat = time();
-
-            return $this;
-        }
-
-        /**
-         * Run a very lightweight query to keep the connection alive
-         * @return void
-         */
-        public function heartbeat($waitForTimeout = true) {
-            if($waitForTimeout) {
-                // Only ping if the timeout 
-                if(isset($this->lastHeartbeat) && time() - $this->lastHeartbeat < max(1, $this->connectTimeout - 30)) {
-                    return;
-                }
-            }
-            $this->lastHeartbeat = time();
-            $this->exec("SELECT 1");
-        }
 
         /**
          * Returns the id of the last inserted element
@@ -311,7 +142,6 @@
             $this->exec("SELECT `" . $field . "` FROM `". $table . "` WHERE `" . $field . "` = ?", "s", $value);
             return ($this->result->num_rows > 0);
         }
-
     }
 
 ?>

--- a/src/main.php
+++ b/src/main.php
@@ -1,10 +1,13 @@
-<?php 
-    use Slim\Factory\ServerRequestCreatorFactory;
+<?php
+
     use Slim\Factory\AppFactory;
-    use ZubZet\Framework\Console\Application;
-    use ZubZet\Framework\Routing\Route;
-    use \Slim\Psr7\Response as HttpResponse;
+    use Slim\Psr7\Response as HttpResponse;
     use Slim\Exception\HttpNotFoundException;
+    use Slim\Factory\ServerRequestCreatorFactory;
+
+    use ZubZet\Framework\Routing\Route;
+    use ZubZet\Framework\Console\Application;
+    use ZubZet\Framework\Database\Connection;
 
     /**
      * Also known as the booter.
@@ -17,8 +20,8 @@
         /** @var array $settings Stores the z_framework settings */
         public $settings;
 
-        /** @var z_db $z_db Database proxy object  */
-        public $z_db;
+        /** @var Connection $z_db Database proxy object  */
+        public Connection $z_db;
 
         /** @var int $maxReroutes Number of reroutes the controller can perform before aborting */
         public $maxReroutes = 10;
@@ -156,9 +159,8 @@
             $this->req = new Request($this);
             $this->res = new Response($this);
 
-            // Import of the z_db
-            require_once $this->z_framework_root.'z_db.php';
-            $this->z_db = new z_db($this);
+            // Import of the database connection
+            $this->z_db = new Connection($this);
 
             // User
             require_once $this->z_framework_root.'z_user.php';

--- a/src/z_response.php
+++ b/src/z_response.php
@@ -54,11 +54,18 @@
                     essentialsHead($opt, $customBootstrap);
                 };
 
-                //Log view
-                $catId = $this->booter->getModel("z_general")->getLogCategoryIdByName("view");
-                $user = $this->booter->user->userId;
-
-                $this->booter->getModel("z_general")->logAction($catId, "URL viewed (User ID: ".$user." ,URL: ".(isset($_SERVER['REQUEST_URI']) ? $_SERVER['REQUEST_URI'] : "console").")", $document);
+                // Optional log view
+                try {
+                    $catId = model("z_general")->getLogCategoryIdByName("view");
+                    $location = $_SERVER['REQUEST_URI'] ?? "console";
+                    model("z_general")->logAction(
+                        $catId,
+                        "URL viewed (User ID: " . user()->userId . " , URL: $location)",
+                        $document,
+                    );
+                } catch (\Exception $e) {
+                    // Do not log this render to avoid having to require a database
+                }
 
                 //Load the document
                 $view = include($viewPath);


### PR DESCRIPTION
- Refactor the `z_db` class to use the normal auto-loading functionality
- Only setup the database connection once the first actual usage happens