### PR TITLE
WIP: add OpenAPI specification generation for registered routes

### DIFF
--- a/.github/workflows/tests_e2e.yml
+++ b/.github/workflows/tests_e2e.yml
@@ -2,29 +2,29 @@ name: E2E tests
 
 on:
   pull_request:
-    branches: [ '*' ]
-    types: [ opened, reopened, synchronize, ready_for_review ]
+    branches: ["*"]
+    types: [opened, reopened, synchronize, ready_for_review]
     paths:
-      - 'tests/e2e/**'
-      - 'composer*'
-      - 'src/**'
-      - '.github/workflows/tests_e2e.yml'
+      - "tests/e2e/**"
+      - "composer*"
+      - "src/**"
+      - ".github/workflows/tests_e2e.yml"
   push:
-    branches: [ '*' ]
-    tags: [ 'v*.*.*' ]
+    branches: ["*"]
+    tags: ["v*.*.*"]
     paths:
-      - 'tests/e2e/**'
-      - 'composer*'
-      - 'src/**'
-      - '.github/workflows/tests_e2e.yml'
+      - "tests/e2e/**"
+      - "composer*"
+      - "src/**"
+      - ".github/workflows/tests_e2e.yml"
   workflow_dispatch:
     inputs:
       scope:
-        description: 'Run scope'
+        description: "Run scope"
         required: false
-        default: 'smoke'
+        default: "smoke"
         type: choice
-        options: [ smoke, full ]
+        options: [smoke, full]
 
 concurrency:
   group: e2e-${{ github.ref }}
@@ -39,13 +39,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php_tag: [
-          "8.0-apache",
-          "8.1-apache",
-          "8.2-apache",
-          "8.3-apache",
-          "8.4-apache"
-        ]
+        php_tag:
+          ["8.0-apache", "8.1-apache", "8.2-apache", "8.3-apache", "8.4-apache"]
 
     env:
       DISABLE_XDEBUG: "1"
@@ -60,23 +55,21 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
         with:
-          node-version: 20
-          cache: npm
-          cache-dependency-path: tests/e2e/package-lock.json
+          bun-version: latest
 
       - name: Cache Cypress binary
         uses: actions/cache@v4
         with:
           path: ~/.cache/Cypress
-          key: cypress-${{ runner.os }}-${{ hashFiles('tests/e2e/package-lock.json') }}
+          key: cypress-${{ runner.os }}-${{ hashFiles('tests/e2e/bun.lockb') }}
           restore-keys: |
             cypress-${{ runner.os }}-
 
-      - name: Install NPM dependencies
-        run: npm ci
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
 
       - name: Detect host UID
         run: echo "HOST_UID=$(id -u)" >> $GITHUB_ENV
@@ -84,7 +77,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      # Build & cache application image once (reuse across future runs)
       - name: Docker build (cached)
         uses: docker/build-push-action@v6
         with:
@@ -100,12 +92,10 @@ jobs:
             USER_UID=${{ env.HOST_UID }}
             DISABLE_XDEBUG=${{ env.DISABLE_XDEBUG }}
 
-      # Warm dependent images so compose doesn't have to pull them during up
       - name: Pre-pull compose services
         run: |
           docker compose -f packaging/docker/docker-compose-base.yml pull || true
 
-      # Bring stack up without rebuilding the already-built image
       - name: Start application stack (no rebuild)
         run: |
           docker compose -f packaging/docker/docker-compose-base.yml up -d --remove-orphans --wait
@@ -121,7 +111,7 @@ jobs:
       - name: Run E2E tests (Cypress)
         env:
           CI: true
-        run: npm run tests
+        run: bun run tests
 
       - name: Upload Cypress videos
         if: failure()

--- a/src/Routing/OpenApiSpec.php
+++ b/src/Routing/OpenApiSpec.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace ZubZet\Framework\Routing;
+
+class OpenApiSpec {
+
+    /**
+     * Generates an OpenAPI 3.0 specification from registered routes.
+     *
+     * @param array[] $routes Registered route metadata
+     * @param array $info OpenAPI info: title, version, description
+     * @return array The OpenAPI spec as an associative array
+     */
+    public static function generate(array $routes, array $info = []): array {
+        $spec = [
+            'openapi' => '3.0.0',
+            'info' => [
+                'title' => $info['title'] ?? 'API',
+                'version' => $info['version'] ?? '1.0.0',
+            ],
+            'paths' => new \stdClass(),
+        ];
+
+        if (isset($info['description'])) {
+            $spec['info']['description'] = $info['description'];
+        }
+
+        $paths = [];
+
+        foreach ($routes as $route) {
+            $method = strtolower($route['method']);
+            $path = $route['endpoint'];
+            $schema = $route['schema'];
+
+            if ($method === 'any') {
+                foreach (['get', 'post', 'put', 'delete', 'patch'] as $m) {
+                    $paths[$path][$m] = self::buildOperation($path, $schema);
+                }
+            } else {
+                $paths[$path][$method] = self::buildOperation($path, $schema);
+            }
+        }
+
+        if (!empty($paths)) {
+            $spec['paths'] = $paths;
+        }
+
+        return $spec;
+    }
+
+    private static function buildOperation(string $path, array $schema): array {
+        $operation = [];
+        $parameters = [];
+
+        // Auto-detect path parameters from {param} placeholders
+        preg_match_all('/\{(\w+)\}/', $path, $matches);
+        $pathParamNames = $matches[1] ?? [];
+
+        // Explicit path params from schema
+        if (isset($schema['params'])) {
+            foreach ($schema['params'] as $name => $def) {
+                $parameters[] = self::buildParameter($name, 'path', $def, true);
+                $pathParamNames = array_diff($pathParamNames, [$name]);
+            }
+        }
+
+        // Add any remaining auto-detected path params not covered by schema
+        foreach ($pathParamNames as $name) {
+            $parameters[] = [
+                'name' => $name,
+                'in' => 'path',
+                'required' => true,
+                'schema' => ['type' => 'string'],
+            ];
+        }
+
+        // Query params
+        if (isset($schema['query'])) {
+            foreach ($schema['query'] as $name => $def) {
+                $parameters[] = self::buildParameter($name, 'query', $def);
+            }
+        }
+
+        // Header params
+        if (isset($schema['headers'])) {
+            foreach ($schema['headers'] as $name => $def) {
+                $parameters[] = self::buildParameter($name, 'header', $def);
+            }
+        }
+
+        if (!empty($parameters)) {
+            $operation['parameters'] = $parameters;
+        }
+
+        // Request body
+        if (isset($schema['body'])) {
+            $operation['requestBody'] = [
+                'content' => [
+                    'application/json' => [
+                        'schema' => $schema['body'],
+                    ],
+                ],
+            ];
+        }
+
+        // Responses
+        if (isset($schema['response'])) {
+            $operation['responses'] = [];
+            foreach ($schema['response'] as $code => $def) {
+                if (isset($def['content'])) {
+                    // Full OpenAPI response object
+                    $operation['responses'][(string)$code] = $def;
+                } else {
+                    // Shorthand: treat as JSON schema
+                    $desc = $def['description'] ?? 'Response';
+                    unset($def['description']);
+                    $operation['responses'][(string)$code] = [
+                        'description' => $desc,
+                        'content' => [
+                            'application/json' => [
+                                'schema' => $def,
+                            ],
+                        ],
+                    ];
+                }
+            }
+        } else {
+            $operation['responses'] = [
+                '200' => ['description' => 'OK'],
+            ];
+        }
+
+        return $operation;
+    }
+
+    private static function buildParameter(string $name, string $in, array $def, bool $forceRequired = false): array {
+        $nonSchemaKeys = ['description', 'required'];
+        $schemaProps = array_diff_key($def, array_flip($nonSchemaKeys));
+
+        $param = [
+            'name' => $name,
+            'in' => $in,
+            'schema' => $schemaProps ?: ['type' => 'string'],
+        ];
+
+        if ($forceRequired || !empty($def['required'])) {
+            $param['required'] = true;
+        }
+
+        if (isset($def['description'])) {
+            $param['description'] = $def['description'];
+        }
+
+        return $param;
+    }
+}
+
+?>

--- a/src/Routing/PendingRoute.php
+++ b/src/Routing/PendingRoute.php
@@ -4,11 +4,18 @@ namespace ZubZet\Framework\Routing;
 
 class PendingRoute extends PendingRoutingState {
 
+    private array $schema = [];
+
     public function __construct(
         private string $method,
         private string $endpoint,
         private array $action,
     ) {}
+
+    public function schema(array $schema): self {
+        $this->schema = $schema;
+        return $this;
+    }
 
     public function __destruct() {
         Route::performRoute(
@@ -16,7 +23,8 @@ class PendingRoute extends PendingRoutingState {
             $this->endpoint,
             $this->action,
             $this->middleware,
-            $this->afterMiddleware
+            $this->afterMiddleware,
+            $this->schema
         );
     }
 }


### PR DESCRIPTION
  Summary                                                                                                                                                                            
                                                                                   
  - Adds a configurable Route::spec() method that registers a GET endpoint serving an auto-generated OpenAPI 3.0 specification                                                       
  - Adds an optional ->schema() fluent method to every route for defining response, query, param, body, and header schemas                                                           
  - Introduces a lightweight OpenApiSpec generator class that builds the spec from collected route metadata

  Usage

  Register the spec endpoint

```
  Route::spec('/openapi', [
      'title' => 'My API',
      'version' => '2.0.0',
      'description' => 'Optional description',
  ]);
```

  Add schemas to routes (all keys optional)

```

  Route::post('/users', [UserController::class, 'action_create'])
      ->schema([
          'body' => [
              'type' => 'object',
              'properties' => [
                  'name' => ['type' => 'string'],
                  'email' => ['type' => 'string', 'format' => 'email'],
              ],
          ],
          'response' => [
              201 => [
                  'type' => 'object',
                  'properties' => [
                      'id' => ['type' => 'integer'],
                  ],
              ],
          ],
      ]);
```

  // Routes without ->schema() still appear in the spec with a default 200 OK response
  Route::delete('/users/{id}', [UserController::class, 'action_delete']);

  Example output at GET /openapi
```

  {
    "openapi": "3.0.0",
    "info": {
      "title": "My API",
      "version": "2.0.0"
    },
    "paths": {
      "/users/{id}": {
        "get": {
          "parameters": [
            {
              "name": "id",
              "in": "path",
              "required": true,
              "schema": { "type": "integer" },
              "description": "User ID"
            },
            {
              "name": "include",
              "in": "query",
              "schema": { "type": "string" },
              "description": "Relations to include"
            },
            {
              "name": "Authorization",
              "in": "header",
              "required": true,
              "schema": { "type": "string" }
            }
          ],
          "responses": {
            "200": {
              "description": "Response",
              "content": {
                "application/json": {
                  "schema": {
                    "type": "object",
                    "properties": {
                      "id": { "type": "integer" },
                      "name": { "type": "string" },
                      "email": { "type": "string" }
                    }
                  }
                }
              }
            },
            "404": {
              "description": "User not found",
              "content": {
                "application/json": {
                  "schema": {}
                }
              }
            }
          }
        },
        "delete": {
          "parameters": [
            {
              "name": "id",
              "in": "path",
              "required": true,
              "schema": { "type": "string" }
            }
          ],
          "responses": {
            "200": { "description": "OK" }
          }
        }
      },
      "/users": {
        "post": {
          "requestBody": {
            "content": {
              "application/json": {
                "schema": {
                  "type": "object",
                  "properties": {
                    "name": { "type": "string" },
                    "email": { "type": "string", "format": "email" }
                  }
                }
              }
            }
          },
          "responses": {
            "201": {
              "description": "Response",
              "content": {
                "application/json": {
                  "schema": {
                    "type": "object",
                    "properties": {
                      "id": { "type": "integer" }
                    }
                  }
                }
              }
            }
          }
        }
      }
    }
  }

```
  Test plan

  - Define Route::spec('/openapi') in a route file and verify GET /openapi returns valid JSON
  - Add ->schema() with all key combinations (params, query, headers, body, response) and verify they appear correctly in the spec
  - Verify routes without ->schema() still appear with a default 200 response
  - Verify path parameters like {id} are auto-detected even without explicit params schema
  - Verify routes inside Route::group() have the full prefixed path in the spec
  - Validate the output against the OpenAPI 3.0 spec using https://editor.swagger.io