### PR TITLE
add static argument support for actions, middlewares and afterwares

### DIFF
--- a/src/Routing/HttpMethod.php
+++ b/src/Routing/HttpMethod.php
@@ -3,36 +3,36 @@
     namespace ZubZet\Framework\Routing;
 
     trait HttpMethod {
-        public static function any(string $endpoint, array|callable $action): PendingRoute {
-            return new PendingRoute(__FUNCTION__, $endpoint, $action);
+        public static function any(string $endpoint, array|callable $action, array $arguments = []): PendingRoute {
+            return new PendingRoute(__FUNCTION__, $endpoint, new PendingAction($action, $arguments));
         }
 
-        public static function get(string $endpoint, array|callable $action): PendingRoute {
-            return new PendingRoute(__FUNCTION__, $endpoint, $action);
+        public static function get(string $endpoint, array|callable $action, array $arguments = []): PendingRoute {
+            return new PendingRoute(__FUNCTION__, $endpoint, new PendingAction($action, $arguments));
         }
 
-        public static function post(string $endpoint, array|callable $action): PendingRoute {
-            return new PendingRoute(__FUNCTION__, $endpoint, $action);
+        public static function post(string $endpoint, array|callable $action, array $arguments = []): PendingRoute {
+            return new PendingRoute(__FUNCTION__, $endpoint, new PendingAction($action, $arguments));
         }
 
-        public static function put(string $endpoint, array|callable $action): PendingRoute {
-            return new PendingRoute(__FUNCTION__, $endpoint, $action);
+        public static function put(string $endpoint, array|callable $action, array $arguments = []): PendingRoute {
+            return new PendingRoute(__FUNCTION__, $endpoint, new PendingAction($action, $arguments));
         }
 
-        public static function delete(string $endpoint, array|callable $action): PendingRoute {
-            return new PendingRoute(__FUNCTION__, $endpoint, $action);
+        public static function delete(string $endpoint, array|callable $action, array $arguments = []): PendingRoute {
+            return new PendingRoute(__FUNCTION__, $endpoint, new PendingAction($action, $arguments));
         }
 
-        public static function patch(string $endpoint, array|callable $action): PendingRoute {
-            return new PendingRoute(__FUNCTION__, $endpoint, $action);
+        public static function patch(string $endpoint, array|callable $action, array $arguments = []): PendingRoute {
+            return new PendingRoute(__FUNCTION__, $endpoint, new PendingAction($action, $arguments));
         }
 
-        public static function options(string $endpoint, array|callable $action): PendingRoute {
-            return new PendingRoute(__FUNCTION__, $endpoint, $action);
+        public static function options(string $endpoint, array|callable $action, array $arguments = []): PendingRoute {
+            return new PendingRoute(__FUNCTION__, $endpoint, new PendingAction($action, $arguments));
         }
 
-        public static function define(string $method, string $endpoint, array|callable $action): PendingRoute {
-            return new PendingRoute($method, $endpoint, $action);
+        public static function define(string $method, string $endpoint, array|callable $action, array $arguments = []): PendingRoute {
+            return new PendingRoute($method, $endpoint, new PendingAction($action, $arguments));
         }
     }
 

--- a/src/Routing/PendingAction.php
+++ b/src/Routing/PendingAction.php
@@ -1,0 +1,22 @@
+<?php 
+
+    namespace ZubZet\Framework\Routing;
+
+    // Dataclass to store pending actions for routes, groups, middlewares and afterwares
+    class PendingAction {
+
+        public $action;
+
+        public function __construct(
+            array|callable $action,
+            public array $arguments = [],
+        ) {
+            $this->action = $action;
+        }
+
+        public function getAction(): array|callable {
+            return $this->action;
+        }
+    }
+
+?>

--- a/src/Routing/PendingRoute.php
+++ b/src/Routing/PendingRoute.php
@@ -4,16 +4,12 @@ namespace ZubZet\Framework\Routing;
 
 class PendingRoute extends PendingRoutingState {
 
-    /** @var callable|array */
-    private $action;
 
     public function __construct(
         private string $method,
         private string $endpoint,
-        callable|array $action,
-    ) {
-        $this->action = $action;
-    }
+        public PendingAction $action,
+    ) {}
 
     public function __destruct() {
         Route::performRoute(

--- a/src/Routing/PendingRoutingState.php
+++ b/src/Routing/PendingRoutingState.php
@@ -7,13 +7,13 @@ class PendingRoutingState {
     public array $middleware = [];
     public array $afterMiddleware = [];
 
-    public function middleware(array $middleware): self {
-        $this->middleware[] = $middleware;
+    public function middleware(array $middleware, array $arguments = []): self {
+        $this->middleware[] = new PendingAction($middleware, $arguments);
         return $this;
     }
 
-    public function afterMiddleware(array $afterMiddleware): self {
-        $this->afterMiddleware[] = $afterMiddleware;
+    public function afterMiddleware(array $afterMiddleware, array $arguments = []): self {
+        $this->afterMiddleware[] = new PendingAction($afterMiddleware, $arguments);
         return $this;
     }
 }

--- a/src/Routing/Route.php
+++ b/src/Routing/Route.php
@@ -86,7 +86,8 @@
             // Execute collected middlewares and exit if any returns any other than true
             foreach($toExecuteMiddlewares as $toExecuteMiddleware) {
                 [$class, $method] = $toExecuteMiddleware;
-                $result = self::callControllerAction($class, $method);
+                $arguments = array_slice($toExecuteMiddleware, 2); // Extract additional arguments if provided
+                $result = self::callControllerAction($class, $method, arguments: $arguments);
                 if($result !== true) exit;
             }
 
@@ -96,7 +97,8 @@
             // Execute after middlewares
             foreach($toExecuteAfterMiddlewares as $toExecuteAfterMiddleware) {
                 [$class, $method] = $toExecuteAfterMiddleware;
-                self::callControllerAction($class, $method);
+                $arguments = array_slice($toExecuteAfterMiddleware, 2); // Extract additional arguments if provided
+                self::callControllerAction($class, $method, arguments: $arguments);
             }
         }
 
@@ -141,9 +143,10 @@
             $handler = function(array $args) use ($action, $effectiveMiddlewares, $effectiveAfterMiddlewares) {
                 foreach($effectiveMiddlewares as $middleware) {
                     [$middlewareClass, $middlewareMethod] = $middleware;
+                    $arguments = array_slice($middleware, 2); // Extract additional arguments if provided
 
                     // Execute the middleware and check its result.
-                    $result = self::callControllerAction($middlewareClass, $middlewareMethod, $args);
+                    $result = self::callControllerAction($middlewareClass, $middlewareMethod, $args, $arguments);
 
                     // Stop processing if middleware returns any other than true.
                     if($result !== true) {
@@ -156,13 +159,15 @@
                     self::performCallableAction($action, $args);
                 } else {
                     [$controllerClass, $actionMethod] = $action;
-                    self::callControllerAction($controllerClass, $actionMethod, $args);
+                    $arguments = array_slice($action, 2); // Extract additional arguments if provided
+                    self::callControllerAction($controllerClass, $actionMethod, $args, $arguments);
                 }
 
                 // After the main action, execute after middlewares.
                 foreach($effectiveAfterMiddlewares as $afterMiddlewareState) {
                     [$afterMiddlewareClass, $afterMiddlewareMethod] = $afterMiddlewareState;
-                    self::callControllerAction($afterMiddlewareClass, $afterMiddlewareMethod, $args);
+                    $arguments = array_slice($afterMiddlewareState, 2); // Extract additional arguments if provided
+                    self::callControllerAction($afterMiddlewareClass, $afterMiddlewareMethod, $args, $arguments);
                 }
             };
 
@@ -250,8 +255,8 @@
             return $afterMiddlewares;
         }
 
-        private static function callControllerAction(string $class, string $method, array $args = []): mixed {
-            return zubzet()->executeControllerAction($class, $method, $args);
+        private static function callControllerAction(string $class, string $method, array $args = [], array $arguments = []): mixed {
+            return zubzet()->executeControllerAction($class, $method, $args, $arguments);
         }
     }
 

--- a/src/Routing/Route.php
+++ b/src/Routing/Route.php
@@ -85,9 +85,8 @@
 
             // Execute collected middlewares and exit if any returns any other than true
             foreach($toExecuteMiddlewares as $toExecuteMiddleware) {
-                [$class, $method] = $toExecuteMiddleware;
-                $arguments = array_slice($toExecuteMiddleware, 2); // Extract additional arguments if provided
-                $result = self::callControllerAction($class, $method, arguments: $arguments);
+                [$class, $method] = $toExecuteMiddleware->getAction();
+                $result = self::callControllerAction($class, $method, arguments: $toExecuteMiddleware->arguments);
                 if($result !== true) exit;
             }
 
@@ -96,9 +95,8 @@
 
             // Execute after middlewares
             foreach($toExecuteAfterMiddlewares as $toExecuteAfterMiddleware) {
-                [$class, $method] = $toExecuteAfterMiddleware;
-                $arguments = array_slice($toExecuteAfterMiddleware, 2); // Extract additional arguments if provided
-                self::callControllerAction($class, $method, arguments: $arguments);
+                [$class, $method] = $toExecuteAfterMiddleware->getAction();
+                self::callControllerAction($class, $method, arguments: $toExecuteAfterMiddleware->arguments);
             }
         }
 
@@ -127,7 +125,7 @@
             array_pop(self::$prefixStack);
         }
 
-        public static function performRoute(string $method, string $endpoint, array|callable $action, array $middlewares, array $afterMiddleware): void {
+        public static function performRoute(string $method, string $endpoint, PendingAction $action, array $middlewares, array $afterMiddleware): void {
             $router = self::getCurrentRouter();
 
             $effectiveMiddlewares = [
@@ -142,11 +140,10 @@
 
             $handler = function(array $args) use ($action, $effectiveMiddlewares, $effectiveAfterMiddlewares) {
                 foreach($effectiveMiddlewares as $middleware) {
-                    [$middlewareClass, $middlewareMethod] = $middleware;
-                    $arguments = array_slice($middleware, 2); // Extract additional arguments if provided
+                    [$middlewareClass, $middlewareMethod] = $middleware->getAction();
 
                     // Execute the middleware and check its result.
-                    $result = self::callControllerAction($middlewareClass, $middlewareMethod, $args, $arguments);
+                    $result = self::callControllerAction($middlewareClass, $middlewareMethod, $args, $middleware->arguments);
 
                     // Stop processing if middleware returns any other than true.
                     if($result !== true) {
@@ -155,19 +152,17 @@
                 }
 
                 // Execute the main action, which can be either a callable or a controller action.
-                if(is_callable($action)) {
-                    self::performCallableAction($action, $args);
+                if(is_callable($action->getAction())) {
+                    self::performCallableAction($action->getAction(), $args);
                 } else {
-                    [$controllerClass, $actionMethod] = $action;
-                    $arguments = array_slice($action, 2); // Extract additional arguments if provided
-                    self::callControllerAction($controllerClass, $actionMethod, $args, $arguments);
+                    [$controllerClass, $actionMethod] = $action->getAction();
+                    self::callControllerAction($controllerClass, $actionMethod, $args, $action->arguments);
                 }
 
                 // After the main action, execute after middlewares.
                 foreach($effectiveAfterMiddlewares as $afterMiddlewareState) {
-                    [$afterMiddlewareClass, $afterMiddlewareMethod] = $afterMiddlewareState;
-                    $arguments = array_slice($afterMiddlewareState, 2); // Extract additional arguments if provided
-                    self::callControllerAction($afterMiddlewareClass, $afterMiddlewareMethod, $args, $arguments);
+                    [$afterMiddlewareClass, $afterMiddlewareMethod] = $afterMiddlewareState->getAction();
+                    self::callControllerAction($afterMiddlewareClass, $afterMiddlewareMethod, $args, $afterMiddlewareState->arguments);
                 }
             };
 

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -92,7 +92,7 @@
             return $this->routeDispatcher;
         }
 
-        public function executeControllerAction($controller, $action, array $params = []) {
+        public function executeControllerAction($controller, $action, array $params = [], array $arguments = []) {
             $this->req->urlParameters = $params;
 
             $controller = urldecode($controller);
@@ -131,12 +131,12 @@
             try {
                 $CTRL_obj = new $controller($this->req, $this->res);
                 if (method_exists($controller, $method)) {
-                    return $CTRL_obj->{$method}($this->req, $this->res);
+                    return $CTRL_obj->{$method}($this->req, $this->res, ...$arguments);
                 } else {
                     //Checks if the fallback method exists before rerouting to the 404 page
                     $method = "action_fallback";
                     if (method_exists($controller, $method)) {
-                        return $CTRL_obj->{$method}($this->req, $this->res);
+                        return $CTRL_obj->{$method}($this->req, $this->res, ...$arguments);
                     } else {
                         return $this->executePath(["error", "404"]);
                     }

--- a/tests/e2e/app/Controllers/CoreController.php
+++ b/tests/e2e/app/Controllers/CoreController.php
@@ -184,6 +184,29 @@
             print_r($req->getRouteParameter());
         }
 
+        // Action which prints arguments
+        public function TestRoute_WithArguments(Request $req, Response $res, $arg1 = null, $arg2 = null) {
+            print_r("TestRoute Executed");
+            print_r($req->getRouteParameter());
+            echo " Args: $arg1 $arg2";
+        }
+
+        // Middleware which prints and accepts
+        public function Route_Middleware_Accept_WithArguments(Request $req, Response $res, $arg1 = null, $arg2 = null) {
+            print_r("Route Middleware Accept Executed");
+            print_r($req->getRouteParameter());
+            echo " Args: $arg1 $arg2";
+            return true;
+        }
+
+        // Afterware which prints arguments
+        public function Route_Afterware_WithArguments(Request $req, Response $res, $arg1 = null, $arg2 = null) {
+            print_r("Route Afterware Executed");
+            print_r($req->getRouteParameter());
+            echo " Args: $arg1 $arg2";
+        }
+        
+
 
         /**
          * Testing the Query Builder

--- a/tests/e2e/app/Routes/CypressRoutes.php
+++ b/tests/e2e/app/Routes/CypressRoutes.php
@@ -1,6 +1,25 @@
 <?php
     use ZubZet\Framework\Routing\Route;
 
+    Route::group('/arguments', function() {
+        Route::get('/action', [CoreController::class, 'TestRoute_WithArguments', 'abc', 123]);
+
+        Route::get('/middleware-accept', [CoreController::class, 'TestRoute_WithArguments'])
+            ->middleware([CoreController::class, 'Route_Middleware_Accept_WithArguments', 'abc', 123]);
+
+        Route::get('/middleware-block', [CoreController::class, 'TestRoute_WithArguments'])
+            ->middleware([CoreController::class, 'Route_Middleware_Block', 'abc', 123]);
+
+        Route::get('/afterware', [CoreController::class, 'TestRoute_WithArguments'])
+            ->afterMiddleware([CoreController::class, 'Route_Afterware_WithArguments', 'abc', 123]);
+
+        Route::get('/all', [CoreController::class, 'TestRoute_WithArguments', 'abc', 123])
+            ->middleware([CoreController::class, 'Route_Middleware_Accept_WithArguments', 'def', 456])
+            ->afterMiddleware([CoreController::class, 'Route_Afterware_WithArguments', 'ghi', 789]);
+
+        Route::get('/{userId}/action', [CoreController::class, 'TestRoute_WithArguments', 'abc', 123]);
+    });
+
     // it should execute "Route_Middleware_Accept" and then block by "Route_Middleware_Block" (no afterware or route action should be executed)
     Route::group('/RouteDeny', function() {})
         ->middleware([CoreController::class, 'Route_Middleware_Accept'])

--- a/tests/e2e/app/Routes/CypressRoutes.php
+++ b/tests/e2e/app/Routes/CypressRoutes.php
@@ -2,19 +2,19 @@
     use ZubZet\Framework\Routing\Route;
 
     Route::group('/arguments', function() {
-        Route::get('/action', [CoreController::class, 'TestRoute_WithArguments', 'abc', 123]);
+        Route::get('/action', [CoreController::class, 'TestRoute_WithArguments'], ['abc', 123]);
 
         Route::get('/middleware-accept', [CoreController::class, 'TestRoute_WithArguments'])
-            ->middleware([CoreController::class, 'Route_Middleware_Accept_WithArguments', 'abc', 123]);
+            ->middleware([CoreController::class, 'Route_Middleware_Accept_WithArguments'], ['abc', 123]);
 
         Route::get('/afterware', [CoreController::class, 'TestRoute_WithArguments'])
-            ->afterMiddleware([CoreController::class, 'Route_Afterware_WithArguments', 'abc', 123]);
+            ->afterMiddleware([CoreController::class, 'Route_Afterware_WithArguments'], ['abc', 123]);
 
-        Route::get('/all', [CoreController::class, 'TestRoute_WithArguments', 'abc', 123])
-            ->middleware([CoreController::class, 'Route_Middleware_Accept_WithArguments', 'def', 456])
-            ->afterMiddleware([CoreController::class, 'Route_Afterware_WithArguments', 'ghi', 789]);
+        Route::get('/all', [CoreController::class, 'TestRoute_WithArguments'], ['abc', 123])
+            ->middleware([CoreController::class, 'Route_Middleware_Accept_WithArguments'], ['def', 456])
+            ->afterMiddleware([CoreController::class, 'Route_Afterware_WithArguments'], ['ghi', 789]);
 
-        Route::get('/{userId}/action', [CoreController::class, 'TestRoute_WithArguments', 'abc', 123]);
+        Route::get('/{userId}/action', [CoreController::class, 'TestRoute_WithArguments'], ['abc', 123]);
     });
 
     // it should execute "Route_Middleware_Accept" and then block by "Route_Middleware_Block" (no afterware or route action should be executed)

--- a/tests/e2e/app/Routes/CypressRoutes.php
+++ b/tests/e2e/app/Routes/CypressRoutes.php
@@ -7,9 +7,6 @@
         Route::get('/middleware-accept', [CoreController::class, 'TestRoute_WithArguments'])
             ->middleware([CoreController::class, 'Route_Middleware_Accept_WithArguments', 'abc', 123]);
 
-        Route::get('/middleware-block', [CoreController::class, 'TestRoute_WithArguments'])
-            ->middleware([CoreController::class, 'Route_Middleware_Block', 'abc', 123]);
-
         Route::get('/afterware', [CoreController::class, 'TestRoute_WithArguments'])
             ->afterMiddleware([CoreController::class, 'Route_Afterware_WithArguments', 'abc', 123]);
 

--- a/tests/e2e/tests/cypress/e2e/core/routing.cy.js
+++ b/tests/e2e/tests/cypress/e2e/core/routing.cy.js
@@ -224,22 +224,17 @@ describe('Routing', () => {
         // Arguments on afterware
         {
             route: "/arguments/afterware",
-            expected: "TestRoute ExecutedArray ( ) Route Afterware ExecutedArray ( ) Args: abc 123"
+            expected: "TestRoute ExecutedArray ( ) Args: Route Afterware ExecutedArray ( ) Args: abc 123"
         },
         // Arguments on all three
         {
             route: "/arguments/all",
-            expected: "Route Middleware Accept ExecutedArray ( ) Args: def 456 TestRoute ExecutedArray ( ) Args: abc 123 Route Afterware ExecutedArray ( ) Args: ghi 789"
+            expected: "Route Middleware Accept ExecutedArray ( ) Args: def 456TestRoute ExecutedArray ( ) Args: abc 123Route Afterware ExecutedArray ( ) Args: ghi 789"
         },
         // Arguments combined with route parameters
         {
             route: "/arguments/U13/action",
             expected: "TestRoute ExecutedArray ( [userId] => U13 ) Args: abc 123"
-        },
-        // Blocking middleware still receives arguments
-        {
-            route: "/arguments/middleware-block",
-            expected: "Route Middleware Blocked ExecutedArray ( ) Args: abc 123"
         },
     ];
 

--- a/tests/e2e/tests/cypress/e2e/core/routing.cy.js
+++ b/tests/e2e/tests/cypress/e2e/core/routing.cy.js
@@ -219,7 +219,7 @@ describe('Routing', () => {
         // Arguments on middleware (accept)
         {
             route: "/arguments/middleware-accept",
-            expected: "Route Middleware Accept ExecutedArray ( ) Args: abc 123 TestRoute ExecutedArray ( )"
+            expected: "Route Middleware Accept ExecutedArray ( ) Args: abc 123TestRoute ExecutedArray ( ) Args:"
         },
         // Arguments on afterware
         {

--- a/tests/e2e/tests/cypress/e2e/core/routing.cy.js
+++ b/tests/e2e/tests/cypress/e2e/core/routing.cy.js
@@ -211,6 +211,36 @@ describe('Routing', () => {
             route: "/accept-afterware-parameters/U13/P12/middleware-block-afterware",
             expected: "Group Middleware Accept ExecutedArray ( [userId] => U13 [postId] => P12 ) Route Middleware Blocked ExecutedArray ( [userId] => U13 [postId] => P12 ) "
         },
+        // Arguments on action
+        {
+            route: "/arguments/action",
+            expected: "TestRoute ExecutedArray ( ) Args: abc 123"
+        },
+        // Arguments on middleware (accept)
+        {
+            route: "/arguments/middleware-accept",
+            expected: "Route Middleware Accept ExecutedArray ( ) Args: abc 123 TestRoute ExecutedArray ( )"
+        },
+        // Arguments on afterware
+        {
+            route: "/arguments/afterware",
+            expected: "TestRoute ExecutedArray ( ) Route Afterware ExecutedArray ( ) Args: abc 123"
+        },
+        // Arguments on all three
+        {
+            route: "/arguments/all",
+            expected: "Route Middleware Accept ExecutedArray ( ) Args: def 456 TestRoute ExecutedArray ( ) Args: abc 123 Route Afterware ExecutedArray ( ) Args: ghi 789"
+        },
+        // Arguments combined with route parameters
+        {
+            route: "/arguments/U13/action",
+            expected: "TestRoute ExecutedArray ( [userId] => U13 ) Args: abc 123"
+        },
+        // Blocking middleware still receives arguments
+        {
+            route: "/arguments/middleware-block",
+            expected: "Route Middleware Blocked ExecutedArray ( ) Args: abc 123"
+        },
     ];
 
     it('should check the Routing-System with all routes', () => {


### PR DESCRIPTION
Closes #76 


This PR allows to define arguments, which will be passed to the action.

**Example:**
```
Route::get('/action', [CoreController::class, 'TestRoute_WithArguments'], ['abc', 123]);
```

```
public function TestRoute_WithArguments(Request $req, Response $res, $arg1 = null, $arg2 = null) {
            print_r("TestRoute Executed");
            echo " Args: $arg1 $arg2";
        }
```