### PR TITLE
add info:startup command for server startup info

### DIFF
--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -8,6 +8,7 @@
     use ZubZet\Framework\Database\Migration\Commands\Status;
     use ZubZet\Framework\Database\Migration\Commands\Sync;
     use ZubZet\Framework\Database\Migration\Commands\UnlockMigration;
+    use ZubZet\Framework\Support\Commands\Startup;
 
     class Application {
         public static function bootstrap(\z_framework $booter): ConsoleApplication {
@@ -24,6 +25,7 @@
                     new Sync(),
                     new Seed(),
                     new UnlockMigration(),
+                    new Startup(),
                 ],
             ));
             return $console;

--- a/src/Support/Commands/Startup.php
+++ b/src/Support/Commands/Startup.php
@@ -28,20 +28,19 @@
             $out->getFormatter()->setStyle("bar", new OutputFormatterStyle("magenta"));
 
             $version = $this->getInstalledVersion();
-            $pageName = config('pageName', default: '');
-            $executionType = config('execution_type', default: 'unknown');
-            $assetVersion = config('assetVersion', default: 'unknown');
-            $phpVersion = PHP_VERSION;
+            $pageName = config('pageName', default: 'Unknown. Set pageName in settings!');
+            $executionType = config('execution_type', default: 'Unknown. Set execution_type in settings!');
+            $assetVersion = config('assetVersion', default: 'Unknown. Set assetVersion in settings!');
 
             $this->line();
             $this->line("<brand>▲ ZubZet</brand>  <version>{$version}</version>  {$pageName}");
             $this->line();
-            $this->importantRow("Local", $this->getConfiguredHost());
+            $this->line("<bar>┃</bar>  <label>Open:</label>  <url>{$this->getConfiguredHost()}</url>");
             $this->line();
             $this->line("<muted>─────────────────────────────────────────────</muted>");
-            $this->infoRow("env", $executionType);
-            $this->infoRow("php", "v{$phpVersion}");
-            $this->infoRow("assets", "v{$assetVersion}");
+            $this->infoRow("Environment", $executionType);
+            $this->infoRow("PHP Runtime", "v" . PHP_VERSION . "");
+            $this->infoRow("Assets", "v{$assetVersion}");
             $this->line("<muted>─────────────────────────────────────────────</muted>");
             $this->line();
             $this->line("<muted>run</muted> <label>'npm run stop'</label> <muted>to stop the server</muted>");
@@ -50,22 +49,12 @@
             return Command::SUCCESS;
         }
 
-        private function line(?string $content = null): void {
-            // Append two spaced at the beginning of the line for better readability
-            $output = "  {$content}";
-
-            // If there is no content, just print an empty line without spaces
-            if(is_null($content)) $output = "";
-
-            $this->out->writeln($output);
-        }
-
-        private function importantRow(string $label, string $url): void {
-            $this->line("<bar>┃</bar>  <label>{$label}</label>  <url>{$url}</url>");
+        private function line(string $content = ""): void {
+            $this->out->writeln("  {$content}");
         }
 
         private function infoRow(string $label, string $value): void {
-            $this->line("<muted>{$label}</muted>  <label>{$value}</label>");
+            $this->line("<muted>{$label}</muted>\t<label>{$value}</label>");
         }
 
         private function getInstalledVersion(): string {
@@ -73,15 +62,7 @@
         }
 
         private function getConfiguredHost(): string {
-            return rtrim($this->config('host', 'http://localhost'), '/');
-        }
-
-        private function config(string $key, string $default = 'unknown'): string {
-            try {
-                return (string) zubzet()->{$key};
-            } catch (\Throwable) {
-                return $default;
-            }
+            return config('host', default: 'Unknown / Check docker-compose-base.yml');
         }
 
     }

--- a/src/Support/Commands/Startup.php
+++ b/src/Support/Commands/Startup.php
@@ -1,0 +1,87 @@
+<?php
+    namespace ZubZet\Framework\Support\Commands;
+
+    use Composer\InstalledVersions;
+    use Symfony\Component\Console\Command\Command;
+    use Symfony\Component\Console\Input\InputInterface;
+    use Symfony\Component\Console\Output\OutputInterface;
+    use Symfony\Component\Console\Formatter\OutputFormatterStyle;
+
+    final class Startup extends Command {
+
+        private OutputInterface $out;
+
+        protected function configure(): void {
+            $this->setName("info:startup");
+            $this->setDescription("Prints information for the startup process of the framework.");
+        }
+
+        protected function execute(InputInterface $_in, OutputInterface $out): int {
+            $this->out = $out;
+            $out->setDecorated(true);
+
+            $out->getFormatter()->setStyle("brand", new OutputFormatterStyle("magenta", null, ["bold"]));
+            $out->getFormatter()->setStyle("version", new OutputFormatterStyle("gray"));
+            $out->getFormatter()->setStyle("label", new OutputFormatterStyle("white", null, ["bold"]));
+            $out->getFormatter()->setStyle("url", new OutputFormatterStyle("cyan"));
+            $out->getFormatter()->setStyle("muted", new OutputFormatterStyle("gray"));
+            $out->getFormatter()->setStyle("bar", new OutputFormatterStyle("magenta"));
+
+            $version = $this->getInstalledVersion();
+            $pageName = config('pageName', default: '');
+            $executionType = config('execution_type', default: 'unknown');
+            $assetVersion = config('assetVersion', default: 'unknown');
+            $phpVersion = PHP_VERSION;
+
+            $this->line();
+            $this->line("<brand>▲ ZubZet</brand>  <version>{$version}</version>  {$pageName}");
+            $this->line();
+            $this->importantRow("Local", $this->getConfiguredHost());
+            $this->line();
+            $this->line("<muted>─────────────────────────────────────────────</muted>");
+            $this->infoRow("env", $executionType);
+            $this->infoRow("php", "v{$phpVersion}");
+            $this->infoRow("assets", "v{$assetVersion}");
+            $this->line("<muted>─────────────────────────────────────────────</muted>");
+            $this->line();
+            $this->line("<muted>run</muted> <label>'npm run stop'</label> <muted>to stop the server</muted>");
+            $this->line();
+
+            return Command::SUCCESS;
+        }
+
+        private function line(?string $content = null): void {
+            // Append two spaced at the beginning of the line for better readability
+            $output = "  {$content}";
+
+            // If there is no content, just print an empty line without spaces
+            if(is_null($content)) $output = "";
+
+            $this->out->writeln($output);
+        }
+
+        private function importantRow(string $label, string $url): void {
+            $this->line("<bar>┃</bar>  <label>{$label}</label>  <url>{$url}</url>");
+        }
+
+        private function infoRow(string $label, string $value): void {
+            $this->line("<muted>{$label}</muted>  <label>{$value}</label>");
+        }
+
+        private function getInstalledVersion(): string {
+            return InstalledVersions::getPrettyVersion('zubzet/framework') ?? 'unknown';
+        }
+
+        private function getConfiguredHost(): string {
+            return rtrim($this->config('host', 'http://localhost'), '/');
+        }
+
+        private function config(string $key, string $default = 'unknown'): string {
+            try {
+                return (string) zubzet()->{$key};
+            } catch (\Throwable) {
+                return $default;
+            }
+        }
+
+    }

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -7,10 +7,11 @@
     "private": true,
     "scripts": {
         "docker-compose": "docker compose -f packaging/docker/docker-compose-base.yml",
-        "start": "npm install && npm run docker-compose -- up --remove-orphans --build -d && docker exec application composer install && npm run seed",
+        "start": "npm install && npm run docker-compose -- up --remove-orphans --build -d && docker exec application composer install && npm run seed && npm run info",
         "stop": "npm run docker-compose -- down -v",
         "shell": "docker exec -it application bash",
         "seed": "docker exec application php index.php db:seed",
+        "info": "docker exec application php index.php info:startup",
         "cypress": "cypress open --project tests",
         "tests": "env -u ELECTRON_RUN_AS_NODE cypress run --project tests"
     },

--- a/tests/e2e/tests/cypress/e2e/advanced/info-startup.cy.js
+++ b/tests/e2e/tests/cypress/e2e/advanced/info-startup.cy.js
@@ -1,0 +1,22 @@
+describe('info:startup Command', () => {
+
+    it('prints the startup info', () => {
+        cy.exec('docker exec application php index.php info:startup').then((result) => {
+            const output = result.stdout;
+
+            expect(output).to.include('ZubZet');
+            expect(output).to.include('Local');
+            expect(output).to.include('env');
+            expect(output).to.include('php');
+            expect(output).to.include('assets');
+            expect(output).to.include('npm run stop');
+        });
+    });
+
+    it('exits with code 0', () => {
+        cy.exec('docker exec application php index.php info:startup', { failOnNonZeroExit: false }).then((result) => {
+            expect(result.exitCode).to.equal(0);
+        });
+    });
+
+});


### PR DESCRIPTION
## Changes
Added a new `info:startup` command that prints an overview of the running instance.


<img width="698" height="391" alt="Screenshot from 2026-04-10 10-28-15" src="https://github.com/user-attachments/assets/2dc0d46b-cf44-47e4-846a-5dd5e8245558" />
