### PR TITLE
feat(seed): add include/exclude environment path filtering to db:seed

### DIFF
--- a/docs/core-features/migrations/index.md
+++ b/docs/core-features/migrations/index.md
@@ -282,10 +282,22 @@ The **Seed** command is used to **completely recreate the database** and then in
 
 #### Available Options
 
+By default, `db:seed` executes **all** seed files found in `app/Database/seed`.
+
 * **`skip-migrations`** | **`-s`**  
 Skips the migration process and executes only the seeding step.
 > **Details:** Use this flag when you want to populate the database with seed data without re-running migrations. This is useful when your database schema is already up-to-date and you only need to insert or update seed data without resetting the database.  
 > **Usage:** `db:seed -s`
+
+* **`environments-excluded`** | **`-e`**  
+Excludes matching seed folders or files from execution.
+> **Details:** Matches are path-based (relative to `app/Database/seed`). You can exclude a complete folder (for example `Environments`) or a single file (for example `Environments/Testing/Chat.sql`).  
+> **Usage:** `db:seed -e Environments`
+
+* **`environments-included`** | **`-i`**  
+Re-includes matching seed folders or files **after** exclusions are applied.
+> **Details:** This allows a two-step flow: first exclude a broad path, then include a specific subset again (folder or single file).  
+> **Usage:** `db:seed -e Environments -i Environments/Testing`
 
 
 **Execution Workflow**

--- a/src/Database/Migration/Commands/Seed.php
+++ b/src/Database/Migration/Commands/Seed.php
@@ -26,6 +26,20 @@
                 "Runs the seeding process without running the migrations first.",
             );
 
+            $this->addOption(
+                "environments-included",
+                "i",
+                InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
+                "Include seed folders/files after excludes are applied",
+            );
+
+            $this->addOption(
+                "environments-excluded",
+                "e",
+                InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
+                "Exclude seed folders/files from execution",
+            );
+
             $this->setDatabaseConnection();
         }
 
@@ -34,13 +48,24 @@
             $out->writeln("<comment>Seeding started at: " . date("Y-m-d H:i:s") . "</comment>");
 
             $skipMigrations = $in->getOption("skip-migrations");
+            $includedEnvironmentPaths = $in->getOption("environments-included");
+            $excludedEnvironmentPaths = $in->getOption("environments-excluded");
 
             if(!$skipMigrations) {
                 $out->writeln("<comment>Running migrations before seeding...</comment>");
                 $this->resetDatabase($out);
             }
 
-            $seedFiles = model("z_migration")->getFiles("./app/Database/seed");
+            $seedRoot = "./app/Database/seed";
+            $seedFiles = model("z_migration")->getFiles($seedRoot);
+
+            // Filter seed files based on include/exclude options
+            $seedFiles = $this->filterSeedFiles(
+                $seedFiles,
+                $seedRoot,
+                $excludedEnvironmentPaths,
+                $includedEnvironmentPaths,
+            );
 
             foreach($seedFiles as $seedFile) {
                 try {
@@ -126,6 +151,66 @@
 
             // Buffer the SQL statements and execute them in batches to optimize performance
             $this->bufferedStatements .= "\n-- SEED FILE: $filepath\n$sqlStatement";
+        }
+
+        /**
+         * Seed filtering always starts with all files.
+         * Step 1: remove matching excluded paths.
+         * Step 2: add matching included paths back in.
+         */
+        private function filterSeedFiles(array $seedFiles, string $seedRoot, array $excludedPaths, array $includedPaths): array {
+            // No files -> no filtering needed
+            if(empty($seedFiles)) return [];
+
+            $selectedSeeds = [];
+
+            foreach($seedFiles as $seedFile) {
+                // Exclude any files that match the excluded paths first
+                if($this->matchesAnySelector($seedFile, $excludedPaths, $seedRoot)) continue;
+
+                $selectedSeeds[$seedFile] = true;
+            }
+
+            foreach($seedFiles as $seedFile) {
+                // Then add back in any files that match the included paths, even if they were previously excluded
+                if(!$this->matchesAnySelector($seedFile, $includedPaths, $seedRoot)) continue;
+
+                $selectedSeeds[$seedFile] = true;
+            }
+
+            $filteredSeedFiles = [];
+
+            foreach($seedFiles as $seedFile) {
+                if(!isset($selectedSeeds[$seedFile])) continue;
+
+                // Preserve the original order of the seed files as returned by getFiles()
+                $filteredSeedFiles[] = $seedFile;
+            }
+
+            return $filteredSeedFiles;
+        }
+
+        private function matchesAnySelector(string $seedFile, array $selectors, string $seedRoot): bool {
+            foreach($selectors as $selector) {
+                if(!$this->matchesSelector($seedFile, (string) $selector, $seedRoot)) continue;
+                return true;
+            }
+
+            return false;
+        }
+
+        private function matchesSelector(string $seedFile, string $selector, string $seedRoot): bool {
+            $selector = trim($selector);
+            if($selector === "") return false;
+
+            // Normalize paths to ensure consistent matching
+            $selectorPath = rtrim($seedRoot, "/") . "/" . ltrim($selector, "/");
+
+            // If the selector is a file (e.g. "Environments/Prod/seed.sql"), it matches if the seed file path is exactly the same.
+            if($seedFile === $selectorPath) return true;
+
+            // Otherwise check if the seed file is within the selector folder (e.g. "Environments/Prod/" matches "Environments/Prod/seed.sql")
+            return str_starts_with($seedFile, $selectorPath . "/");
         }
     }
 

--- a/tests/e2e/tests/cypress/e2e/migration/seed.cy.js
+++ b/tests/e2e/tests/cypress/e2e/migration/seed.cy.js
@@ -1,27 +1,76 @@
 describe('Migration System - Import', () => {
 
-    let baseDir = '../app/Database/seed';
-    let fixturesDir = "cypress/fixtures";
+    const baseDir = '../app/Database/seed';
+    const fixturesDir = "cypress/fixtures";
 
     const allFiles = [
         "TestSeeding.sql",
-        "TestSeeding.php"
+        "TestSeeding.php",
+        "Environments/Staging/Chat.sql",
+        "Environments/Staging/Departments.sql",
+        "Environments/Testing/Chat.sql",
+        "Environments/Testing/Departments.sql",
     ];
 
-    it("should check if the seeding works correctly", () => {
-        cy.dbSeed();
-
+    const copySeedFiles = () => {
         allFiles.forEach((file) => {
-            const source = `${fixturesDir}/MigrationFiles/Seeding/${file}`
-            const target = `${baseDir}/${file}`
+            const source = `${fixturesDir}/MigrationFiles/Seeding/${file}`;
+            const target = `${baseDir}/${file}`;
+            const targetDir = target.substring(0, target.lastIndexOf('/'));
 
+            cy.exec(`mkdir -p ${targetDir}`);
             cy.exec(`cp ${source} ${target}`);
         });
+    };
 
+    const removeSeedFiles = () => {
+        allFiles.forEach((file) => {
+            const target = `${baseDir}/${file}`;
+            cy.exec(`rm -f ${target} || true`);
+        });
+    };
+
+    beforeEach(() => {
+        cy.dbSeed();
+        copySeedFiles();
+    });
+
+    it("should check if the seeding works correctly", () => {
         cy.exec('docker exec application php index.php db:seed', { failOnNonZeroExit: false });
         cy.visit("/migration/checkSeeding");
+
         cy.contains("Seed Entry 1");
         cy.contains("Seed Entry 2");
+        cy.contains("Seed Entry Staging Chat");
+        cy.contains("Seed Entry Staging Departments");
+        cy.contains("Seed Entry Testing Chat");
+        cy.contains("Seed Entry Testing Departments");
+    });
+
+    it("should allow excluding and re-including specific seed environments", () => {
+        cy.exec('docker exec application php index.php db:seed -e Environments -i Environments/Testing', { failOnNonZeroExit: false });
+        cy.visit("/migration/checkSeeding");
+
+        cy.contains("Seed Entry 1");
+        cy.contains("Seed Entry 2");
+        cy.contains("Seed Entry Testing Chat");
+        cy.contains("Seed Entry Testing Departments");
+
+        cy.contains("Seed Entry Staging Chat").should("not.exist");
+        cy.contains("Seed Entry Staging Departments").should("not.exist");
+    });
+
+    it("should allow re-including a single seed file", () => {
+        cy.exec('docker exec application php index.php db:seed -e Environments -i Environments/Testing/Chat.sql', { failOnNonZeroExit: false });
+        cy.visit("/migration/checkSeeding");
+
+        cy.contains("Seed Entry 1");
+        cy.contains("Seed Entry 2");
+        cy.contains("Seed Entry Testing Chat");
+
+        cy.contains("Seed Entry Testing Departments").should("not.exist");
+        cy.contains("Seed Entry Staging Chat").should("not.exist");
+        cy.contains("Seed Entry Staging Departments").should("not.exist");
     });
 
     it("should be possible to run the seeding without running the migrations first", () => {
@@ -31,9 +80,6 @@ describe('Migration System - Import', () => {
     });
 
     after(() => {
-        allFiles.forEach((file) => {
-            const target = `${baseDir}/${file}`
-            cy.exec(`rm -f ${target} || true`);
-        });
+        removeSeedFiles();
     });
 });

--- a/tests/e2e/tests/cypress/fixtures/MigrationFiles/Seeding/Environments/Staging/Chat.sql
+++ b/tests/e2e/tests/cypress/fixtures/MigrationFiles/Seeding/Environments/Staging/Chat.sql
@@ -1,0 +1,1 @@
+INSERT INTO `migration_seed` (`name`) VALUES ('Seed Entry Staging Chat');

--- a/tests/e2e/tests/cypress/fixtures/MigrationFiles/Seeding/Environments/Staging/Departments.sql
+++ b/tests/e2e/tests/cypress/fixtures/MigrationFiles/Seeding/Environments/Staging/Departments.sql
@@ -1,0 +1,1 @@
+INSERT INTO `migration_seed` (`name`) VALUES ('Seed Entry Staging Departments');

--- a/tests/e2e/tests/cypress/fixtures/MigrationFiles/Seeding/Environments/Testing/Chat.sql
+++ b/tests/e2e/tests/cypress/fixtures/MigrationFiles/Seeding/Environments/Testing/Chat.sql
@@ -1,0 +1,1 @@
+INSERT INTO `migration_seed` (`name`) VALUES ('Seed Entry Testing Chat');

--- a/tests/e2e/tests/cypress/fixtures/MigrationFiles/Seeding/Environments/Testing/Departments.sql
+++ b/tests/e2e/tests/cypress/fixtures/MigrationFiles/Seeding/Environments/Testing/Departments.sql
@@ -1,0 +1,1 @@
+INSERT INTO `migration_seed` (`name`) VALUES ('Seed Entry Testing Departments');


### PR DESCRIPTION
This allows you to selectively control which seeds are imported.

**Example:**
Given the following seed structure:

```bash
./0_permissions.sql
./1_users.sql
./Environments/Staging/posts.sql
./Environments/Testing/posts.sql
```

By default, all seed files are executed.

With the following command, you can refine the import behavior:

```bash
db:seed -e Environments -i Environments/Testing
```

This will first exclude the entire `Environments` directory from the import.
Then, it will explicitly include the `Environments/Testing` directory, so only those seeds are executed.