### PR TITLE
test(db): smoke test for BIGINT z_file.size

### DIFF
--- a/tests/e2e/app/Controllers/CoreController.php
+++ b/tests/e2e/app/Controllers/CoreController.php
@@ -350,6 +350,10 @@
             $res->sendEmailToUser(1, "This is a Test Email Static", "email/Static", [], "email");
         }
 
+        public function action_bigintFileSize(Request $req, Response $res) {
+            echo json_encode($req->getModel("Core")->insertLargeFile());
+        }
+
         public function action_sendemailtouser_dynamic(Request $req, Response $res) {
             $res->sendEmailToUser(1, "This is a Test Email Dynamic", "email/Dynamic", [
                 "test_data" => "Test Data 1", 

--- a/tests/e2e/app/Models/CoreModel.php
+++ b/tests/e2e/app/Models/CoreModel.php
@@ -41,6 +41,24 @@
                     VALUES ('LastId')";
             return $this->exec($sql)->getInsertId();
         }
-    } 
+
+        public function insertLargeFile() {
+            $assetId = model("z_file")->add(
+                "bigint-test",
+                "test/virtual",
+                "virtual",
+                "bin",
+                FILE_SIZE_100GB,
+            );
+
+            $sql = "SELECT `size` FROM `z_file` WHERE `id` = ?";
+            $row = $this->exec($sql, "i", $assetId)->resultToLine();
+
+            return [
+                "input" => (string) FILE_SIZE_100GB,
+                "stored" => (string) $row["size"],
+            ];
+        }
+    }
 
 ?>

--- a/tests/e2e/tests/cypress/e2e/form/file.cy.js
+++ b/tests/e2e/tests/cypress/e2e/form/file.cy.js
@@ -143,4 +143,11 @@ describe('Form Date Validation', () => {
         cy.contains("TestFile_Small_2.pdf");
         cy.contains("FormUpload:3");
     });
+
+    it('should store file sizes beyond INT range', () => {
+        cy.request('/Core/bigintFileSize').then((response) => {
+            expect(response.status).to.eq(200);
+            expect(response.body.stored).to.equal(response.body.input);
+        });
+    });
 });


### PR DESCRIPTION
## Summary
- Adds an e2e smoke test that inserts a `FILE_SIZE_100GB` value into `z_file.size` via the framework's `z_file` model and asserts the stored value round-trips without truncation.
- #119 was already addressed on main by commit d408d10 (`fix(db): change z_file.size to BIGINT to support large files`, `src/IncludedComponents/database/Migration/2026-01-01_file_size.sql`); this PR only adds regression coverage. Closing #119 as already fixed.

## Test plan
- [x] New case in `tests/e2e/tests/cypress/e2e/form/file.cy.js` — inserts via `z_file`, reads back, asserts `stored === input`.
- [x] Full e2e suite: `npm run tests` — 221/221 passing.

Closes #119