### PR TITLE
fix(docs): correct mkdocs edit_uri

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,7 +7,7 @@ site_description: A modular, prototyping speed oriented PHP framework.
 # Repository
 repo_name: zubzet/framework
 repo_url: https://github.com/zubzet/framework
-edit_uri: docs/
+edit_uri: edit/main/docs/
 
 # Copyright
 copyright: ZubZet contributors


### PR DESCRIPTION
## Summary
- Fix broken "edit this page" link in the mkdocs-material docs.
- `edit_uri` was `docs/`, producing `https://github.com/zubzet/framework/docs/...` (404).
- Changed to `edit/main/docs/` so the link resolves to GitHub's edit endpoint.

Closes #66

## Test plan
- [x] Verified the generated edit URL opens GitHub's editor in the browser.