### PR TITLE
docs(readme): simplify and point new users to zubzet/zubzet

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,39 +7,19 @@
   A lightweight opinionated PHP framework built with complexity adversity in mind, empowering developers and easy learning.
 </p>
 
-<p align="center">
-  <a href="https://github.com/zubzet/framework"><img alt="GitHub Repo stars" src="https://img.shields.io/badge/Star%20on-GitHub-blue?style=for-the-badge&logo=github"></a>
-  <a href="https://zubzet.com/docs"><img alt="Documentation" src="https://img.shields.io/badge/Read-the%20Docs-brightgreen?style=for-the-badge&logo=readthedocs"></a>
-  <a href="https://packagist.org/packages/zubzet/framework"><img alt="Latest Release" src="https://img.shields.io/badge/Latest%20Release-Packagist-orange?style=for-the-badge&logo=packagist"></a>
-  <a href="https://github.com/zubzet/framework/issues"><img alt="GitHub Issues" src="https://img.shields.io/badge/Report-Issues-yellow?style=for-the-badge&logo=bug"></a>
-  <a href="https://github.com/zubzet/framework/blob/main/LICENSE"><img alt="Apache-2.0 License" src="https://img.shields.io/badge/License-Apache%202.0-blue?style=for-the-badge&logo=apache"></a>
-</p>
+---
 
-<br>
+### Looking to start using ZubZet?
 
-### **Why ZubZet?**
-ZubZet is especially well-suited for process-driven web apps, from internal enterprise tools that manage company workflows and day-to-day operations, to high-traffic public platforms like job boards, and even larger products like media streaming services. Thanks to its lightweight, opinionated core, it’s also a great teaching framework for students who want to learn MVC and build real projects without getting buried in complexity.
+You're in the wrong place. New projects should be created from the starter skeleton:
 
-- **Get Started Quickly:** With sensible defaults and out-of-the-box features, like routing and templating, there’s no steep learning curve. Just install and start building.
+See [zubzet/zubzet](https://github.com/zubzet/zubzet) for the getting-started guide, and the [ZubZet Documentation](https://zubzet.com/docs) for tutorials, guides, and the [API Reference](https://zubzet.com/docs/latest/api).
 
-- **Rapid Development:** Skip the boilerplate. ZubZet’s pre-configured components allow you to prototype and develop your projects faster, while maintaining clean and structured code.
+### Want to contribute?
 
-- **No Barriers for Newcomers:** We believe everyone should have access to great tools. ZubZet is welcoming to newcomers by adhering to principle values like default configurations being ready out of the box, while still allowing for complex setups by advanced users.
+You're in the right place. This repository hosts the framework core that ships as a Composer dependency inside every ZubZet project.
 
-- **Great Portability:** Whether you're developing locally or deploying in a complex production environment, ZubZet is designed to be lightweight, flexible, and portable.
-
-### **A Gentle Approach to MVC**
-
-The framework follows the **Model-View-Controller** (MVC) pattern, but you don’t need to be an expert to get started:
-
-1. **Controllers** handle application logic in a simple, straightforward way.
-2. **Models** manage data interactions with minimal setup, be it a database or other sources.
-3. **Views** allow you to easily create templates that integrate with your data.
-
-### **Documentation**
-Looking for step-by-step guides and practical examples? The [ZubZet Documentation](https://zubzet.com/docs) is the right place to look. It’s packed with tutorials and detailed guides to help you learn the ins and outs of the framework and get started quickly.
-
-### **API Reference**
-Dive deep into the technical details. The comprehensive [API Reference](https://zubzet.com/docs/latest/api) covers every class, method, and parameter to help you customize and extend ZubZet for your specific needs.
-
-There’s no need to trade clarity for capability — build something great without getting bogged down by complexity. ZubZet is here to support your ideas, big or small—let’s build something great, together.
+- **Contribution guide:** [How To Contribute](https://zubzet.com/docs/latest/setup/how-to-contribute)
+- **Documentation:** [zubzet.com/docs](https://zubzet.com/docs)
+- **Report a bug / request a feature:** [Issues](https://github.com/zubzet/framework/issues)
+- **License:** [Apache-2.0](./LICENSE)


### PR DESCRIPTION
## Summary
- Rewrote the README around the audience that actually lands here: contributors and confused users.
- New users are now pointed to the `zubzet/zubzet` starter skeleton (`composer create-project zubzet/zubzet`).
- Dropped the marketing-style "Why ZubZet" / MVC sections and the badges — those belong in the skeleton repo / docs.
- Kept links to the docs, API reference, contribution guide, issues, and license.

Closes #45

## Test plan
- [x] Rendered README locally — both sections read clearly and all links resolve.