### PR TITLE
Add $res->json() method for JSON responses

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -11,3 +11,4 @@ These todos should be as temporary as possible:
 1. Replace Slim with FastRoute
 1. Added info:startup command
 1. Added static arguments in routes, middlewares and afterwares
+1. Added `$res->json()` for sending a JSON response

--- a/docs/core-features/rest-api.md
+++ b/docs/core-features/rest-api.md
@@ -3,14 +3,15 @@
 As the client and the server are completely separated, they need to have a way communicated. It is basically a standardized way of transfering, in our case JSON data, from the server to the client.
 
 ## How to use this?
-There is a file called `z_rest.php`, which handles all the REST responses. You'll probably not be using this as another layer of abstraction exists within the response class. There are two functions regarding this topic. 
+The REST response pipeline lives in `z_rest.php`, but you'll typically reach for one of the response helpers instead:
 
-| Call                      | zdoc                                                                              |
-| ------------------------- | --------------------------------------------------------------------------------- |
-| `$res->generateRest`      | [Here](https://zdoc.zierhut-it.de/classes/Response.html#method_generateRest)      |
-| `$res->generateRestError` | [Here](https://zdoc.zierhut-it.de/classes/Response.html#method_generateRestError) |
-| `$res->error`             | [Here](https://zdoc.zierhut-it.de/classes/Response.html#method_generateRestError) |
-| `$res->success`           | [Here](https://zdoc.zierhut-it.de/classes/Response.html#method_generateRestError) |
+| Call                      | Purpose                                                                     |
+| ------------------------- | --------------------------------------------------------------------------- |
+| `$res->generateRest`      | Sends a REST payload wrapped in a `meta` envelope and exits by default      |
+| `$res->generateRestError` | Sends a REST error envelope                                                 |
+| `$res->error`             | Convenience for `generateRest` with `result=error`                          |
+| `$res->success`           | Convenience for `generateRest` with `result=success`                        |
+| `$res->json`              | Sends a raw JSON payload (no `meta` wrapper); does not exit                 |
 
 You can also just use generateRest for errors. If the key result is set with the value error, it is automatically converted into a REST Error. The second parameter of generateRest called $die determines if the script exits after generating the REST response. The parameter is optional with a default value of true.
 
@@ -51,4 +52,22 @@ $res->error("MESSAGE");
 ```
 ```json
 { "meta": { "endpoint": "REST API", "request": "URL", "timestamp": 9999999 }, "result": "error", "message": "MESSAGE" }
+```
+
+### json
+Use `json` when you need to send a raw JSON payload without the REST `meta` wrapper. It sets `Content-Type: application/json` and echoes `json_encode($data)`. Unlike the other helpers above it does not exit — call `exit` yourself if you need to stop the request here. `JSON_THROW_ON_ERROR` is always applied, so unencodable values raise a `JsonException`.
+
+```php
+$res->json([
+    "ok" => true,
+    "items" => [1, 2, 3],
+]);
+```
+```json
+{"ok":true,"items":[1,2,3]}
+```
+
+Pass extra `json_encode` options as the second argument:
+```php
+$res->json($data, JSON_PRETTY_PRINT);
 ```

--- a/src/Message/Response.php
+++ b/src/Message/Response.php
@@ -117,6 +117,20 @@
         }
 
         /**
+         * Sends a JSON response.
+         *
+         * Sets `Content-Type: application/json` and emits `$data` JSON-encoded.
+         *
+         * @param mixed $data The value to encode as JSON.
+         * @param int $encodingOptions Bitmask of json_encode() options (e.g. JSON_PRETTY_PRINT).
+         * @throws \JsonException If encoding fails. Note that JSON_THROW_ON_ERROR is automatically added to $encodingOptions.
+         */
+        public function json(mixed $data, int $encodingOptions = 0): void {
+            header('Content-Type: application/json');
+            echo json_encode($data, $encodingOptions | JSON_THROW_ON_ERROR);
+        }
+
+        /**
          * Generates a Rest error object
          * @param string $code Code
          * @param string $message Error message


### PR DESCRIPTION
## Summary
- Adds a `Response::json(mixed \$data, int \$encodingOptions = 0): void` helper that sets `Content-Type: application/json` and emits `json_encode(\$data, \$encodingOptions | JSON_THROW_ON_ERROR)`.
- Unlike `generateRest*` helpers, it does not exit and does not wrap in a `meta` envelope — use it when you need to send a raw JSON body.
- Throws `\JsonException` on unencodable values (`JSON_THROW_ON_ERROR` is always applied).
- Documents the new method in `docs/core-features/rest-api.md` and adds a line to `Changelog.md` under v1.2.0.

## Test plan
- [x] `docs/core-features/rest-api.md` renders correctly in the docs site.
- [x] A controller calling `\$res->json(['ok' => true])` returns `{"ok":true}` with `Content-Type: application/json` and status 200.
- [x] Passing a non-encodable value (e.g. a resource or a circular reference) raises `JsonException`.

## Merge order
This PR targets `feature/asset-proxy`. Merge this first, then merge PR #112 into main.