### PR TITLE
Add e2e tests for $res->json()

### DIFF
--- a/tests/e2e/app/Controllers/ResponseController.php
+++ b/tests/e2e/app/Controllers/ResponseController.php
@@ -1,0 +1,12 @@
+<?php
+
+    class ResponseController extends z_controller {
+
+        public function action_json_happy(Request $req, Response $res) {
+            $res->json(["ok" => true]);
+        }
+
+        public function action_json_non_encodable(Request $req, Response $res) {
+            $res->json(fopen("php://memory", "r"));
+        }
+    }

--- a/tests/e2e/tests/cypress/e2e/core/response.cy.js
+++ b/tests/e2e/tests/cypress/e2e/core/response.cy.js
@@ -1,0 +1,20 @@
+describe('Response', () => {
+    describe('json()', () => {
+        it('sends a JSON body with application/json content-type and 200 status', () => {
+            cy.request('/Response/json_happy').then((res) => {
+                expect(res.status).to.eq(200);
+                expect(res.headers['content-type']).to.eq('application/json');
+                expect(res.body).to.deep.eq({ ok: true });
+            });
+        });
+
+        it('raises JsonException when the payload is not encodable', () => {
+            cy.request({
+                url: '/Response/json_non_encodable',
+                failOnStatusCode: false,
+            }).then((res) => {
+                expect(res.body).to.include('JsonException');
+            });
+        });
+    });
+});


### PR DESCRIPTION
Adds cypress e2e coverage for the `$res->json()` helper that landed via #133. Two cases, matching the test plan from #112's description: