### PR TITLE
test(response): sync $res->json() e2e tests into main

### DIFF
--- a/tests/e2e/app/Controllers/ResponseController.php
+++ b/tests/e2e/app/Controllers/ResponseController.php
@@ -1,0 +1,12 @@
+<?php
+
+    class ResponseController extends z_controller {
+
+        public function action_json_happy(Request $req, Response $res) {
+            $res->json(["ok" => true]);
+        }
+
+        public function action_json_non_encodable(Request $req, Response $res) {
+            $res->json(fopen("php://memory", "r"));
+        }
+    }

--- a/tests/e2e/tests/cypress/e2e/core/response.cy.js
+++ b/tests/e2e/tests/cypress/e2e/core/response.cy.js
@@ -1,0 +1,20 @@
+describe('Response', () => {
+    describe('json()', () => {
+        it('sends a JSON body with application/json content-type and 200 status', () => {
+            cy.request('/Response/json_happy').then((res) => {
+                expect(res.status).to.eq(200);
+                expect(res.headers['content-type']).to.eq('application/json');
+                expect(res.body).to.deep.eq({ ok: true });
+            });
+        });
+
+        it('raises JsonException when the payload is not encodable', () => {
+            cy.request({
+                url: '/Response/json_non_encodable',
+                failOnStatusCode: false,
+            }).then((res) => {
+                expect(res.body).to.include('JsonException');
+            });
+        });
+    });
+});


### PR DESCRIPTION
## Summary

Catch-up PR. PR #134 landed the `$res->json()` e2e tests on `feature/asset-proxy` right before #112 merged, so those two files never made it onto `main`:

- `tests/e2e/app/Controllers/ResponseController.php`
- `tests/e2e/tests/cypress/e2e/core/response.cy.js`

This PR brings them over and clears the way to delete the `feature/asset-proxy` branch.