### PR TITLE
fix(deps): bump filp/whoops to ^2.18.4 + restore ALL-mode behavior

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "phpunit/php-code-coverage": "9.*",
         "symfony/filesystem": "v6.0.19",
         "league/mime-type-detection": "^1.16",
-        "filp/whoops": "2.18"
+        "filp/whoops": "^2.18.4"
     },
     "autoload": {
         "files": [

--- a/src/ErrorHandling/ExceptionBehavior.php
+++ b/src/ErrorHandling/ExceptionBehavior.php
@@ -65,10 +65,6 @@
                 set_error_handler(function($severity, $message, $file, $line) {
                     if(!(error_reporting() & $severity)) return false; // respects `@` and error_reporting level
                     self::logError($severity, $message, $file, $line);
-                    // Deprecations in vendor code (e.g. PHP 8.5's (integer) cast in
-                    // whoops/PlainTextHandler) must not become fatal — they would
-                    // cascade inside the exception handler and replace the original.
-                    if($severity & (E_DEPRECATED | E_USER_DEPRECATED)) return true;
                     throw new \ErrorException($message, 0, $severity, $file, $line);
                 });
                 self::registerExceptionHandler();

--- a/tests/e2e/app/Controllers/CoreController.php
+++ b/tests/e2e/app/Controllers/CoreController.php
@@ -14,6 +14,15 @@
             echo "Controller Fallback";
         }
 
+        public function action_throwsException(Request $req, Response $res) {
+            throw new \RuntimeException("regression-controller-exception-marker");
+        }
+
+        public function action_triggersDeprecation(Request $req, Response $res) {
+            trigger_error("regression-controller-deprecation-marker", E_USER_DEPRECATED);
+            echo "deprecation was not promoted";
+        }
+
         public function action_command(Request $req, Response $res) {
             echo json_encode($req->getParameters());
         }

--- a/tests/e2e/composer.json
+++ b/tests/e2e/composer.json
@@ -10,6 +10,7 @@
     }],
 
     "minimum-stability": "dev",
+    "prefer-stable": true,
 
     "require": {
         "zubzet/framework": "*@dev"

--- a/tests/e2e/tests/cypress/e2e/core/controller.cy.js
+++ b/tests/e2e/tests/cypress/e2e/core/controller.cy.js
@@ -40,4 +40,31 @@ describe('Controllers', () => {
         cy.query("title").contains("Render");
         cy.query("data").contains("Data");
     });
+
+    // Regression guards for the Whoops error page pipeline. The bug they cover:
+    // when an uncaught throwable triggered handleException(), loading the Whoops
+    // PrettyPageHandler eagerly autoloaded PlainTextHandler whose `(integer)`
+    // cast emits an E_DEPRECATED on PHP 8.5. ALL-mode promoted that to an
+    // ErrorException inside the exception handler, so the rendered page showed
+    // "Uncaught ErrorException: Non-canonical cast" instead of the real cause.
+    describe('Error rendering (ALL mode)', () => {
+        it('renders the original exception class and message, not a vendor cascade', () => {
+            cy.request({ url: '/Core/throwsException', failOnStatusCode: false }).then((res) => {
+                expect(res.status).to.eq(500);
+                expect(res.body).to.include('regression-controller-exception-marker');
+                expect(res.body).to.include('RuntimeException');
+                expect(res.body).to.not.match(/Non-canonical cast/i);
+                expect(res.body).to.not.include('PlainTextHandler');
+            });
+        });
+
+        it('promotes E_USER_DEPRECATED to a fatal exception (historical ALL contract)', () => {
+            // If a future change skips deprecations, the action's echo runs and
+            // the response is 200 — so the status check is the actual guard.
+            cy.request({ url: '/Core/triggersDeprecation', failOnStatusCode: false }).then((res) => {
+                expect(res.status).to.eq(500);
+                expect(res.body).to.include('regression-controller-deprecation-marker');
+            });
+        });
+    });
 });

--- a/tests/e2e/tests/cypress/e2e/core/controller.cy.js
+++ b/tests/e2e/tests/cypress/e2e/core/controller.cy.js
@@ -40,31 +40,4 @@ describe('Controllers', () => {
         cy.query("title").contains("Render");
         cy.query("data").contains("Data");
     });
-
-    // Regression guards for the Whoops error page pipeline. The bug they cover:
-    // when an uncaught throwable triggered handleException(), loading the Whoops
-    // PrettyPageHandler eagerly autoloaded PlainTextHandler whose `(integer)`
-    // cast emits an E_DEPRECATED on PHP 8.5. ALL-mode promoted that to an
-    // ErrorException inside the exception handler, so the rendered page showed
-    // "Uncaught ErrorException: Non-canonical cast" instead of the real cause.
-    describe('Error rendering (ALL mode)', () => {
-        it('renders the original exception class and message, not a vendor cascade', () => {
-            cy.request({ url: '/Core/throwsException', failOnStatusCode: false }).then((res) => {
-                expect(res.status).to.eq(500);
-                expect(res.body).to.include('regression-controller-exception-marker');
-                expect(res.body).to.include('RuntimeException');
-                expect(res.body).to.not.match(/Non-canonical cast/i);
-                expect(res.body).to.not.include('PlainTextHandler');
-            });
-        });
-
-        it('promotes E_USER_DEPRECATED to a fatal exception (historical ALL contract)', () => {
-            // If a future change skips deprecations, the action's echo runs and
-            // the response is 200 — so the status check is the actual guard.
-            cy.request({ url: '/Core/triggersDeprecation', failOnStatusCode: false }).then((res) => {
-                expect(res.status).to.eq(500);
-                expect(res.body).to.include('regression-controller-deprecation-marker');
-            });
-        });
-    });
 });

--- a/tests/e2e/tests/cypress/e2e/core/exception-handling.cy.js
+++ b/tests/e2e/tests/cypress/e2e/core/exception-handling.cy.js
@@ -1,0 +1,35 @@
+// Regression guards for the ExceptionBehavior trait + Whoops error page.
+//
+// The bug these cover: when an uncaught throwable triggered the new
+// handleException() path in test mode, loading Whoops PrettyPageHandler
+// eagerly pulled in PlainTextHandler whose `(integer)` cast emits an
+// E_DEPRECATED on PHP 8.5. ALL-mode unconditionally promoted that to an
+// ErrorException inside the exception handler, so the rendered page showed
+// "Uncaught ErrorException: Non-canonical cast" instead of the real cause.
+// The proper fix was bumping filp/whoops; the historical contract that
+// ALL-mode promotes every error (deprecations included) must be preserved.
+
+describe('Exception Handling (ALL mode)', () => {
+    before(() => {
+        cy.dbSeed();
+    });
+
+    it('renders the original exception class and message, not a vendor cascade', () => {
+        cy.request({ url: '/Core/throwsException', failOnStatusCode: false }).then((res) => {
+            expect(res.status).to.eq(500);
+            expect(res.body).to.include('regression-controller-exception-marker');
+            expect(res.body).to.include('RuntimeException');
+            expect(res.body).to.not.match(/Non-canonical cast/i);
+            expect(res.body).to.not.include('PlainTextHandler');
+        });
+    });
+
+    it('promotes E_USER_DEPRECATED to a fatal exception (historical ALL contract)', () => {
+        // If a future change skips deprecations, the action's echo runs and
+        // the response is 200 — so the status check is the actual guard.
+        cy.request({ url: '/Core/triggersDeprecation', failOnStatusCode: false }).then((res) => {
+            expect(res.status).to.eq(500);
+            expect(res.body).to.include('regression-controller-deprecation-marker');
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- Bumps `filp/whoops` from pinned `2.18` to `^2.18.4`. The 2.18.4 release replaces the long-form `(integer)` cast in `PlainTextHandler.php:167` with `(int)`, fixing a PHP 8.5 deprecation that — under the new direct `handleException()` invocation introduced by #136 — triggered inside the exception handler and replaced the original throwable with an `Uncaught ErrorException`.
- Reverts the `E_DEPRECATED` skip introduced in `bb24413`. As @zierhut.alex noted, ALL-mode has unconditionally promoted every non-suppressed error to an exception since v1.0.0; the right fix is the dependency bump, not changing the historical contract.
- Adds `prefer-stable: true` to `tests/e2e/composer.json` so the integration test environment resolves to released Symfony Console / Whoops versions instead of moving dev branches. With `minimum-stability: dev` (required for the `*@dev` symlinked framework), composer was otherwise picking `symfony/console: 6.0.x-dev`, which contains an implicit-nullable signature deprecated on PHP 8.4+ and would re-trigger the same fatal cascade.

## Test plan
- [x] PHP 8.0 — full e2e suite (255/255)
- [x] PHP 8.4 — full e2e suite (255/255)
- [x] PHP 8.5 — full e2e suite (255/255)
- [ ] CI run on PRs across the full 8.0–8.5 matrix