### PR TITLE
Feature/form ergonomics

### DIFF
--- a/docs/forms/auto-form-validation.md
+++ b/docs/forms/auto-form-validation.md
@@ -36,6 +36,8 @@ The form is created with `Z.Forms.create`. The `dom` attribute takes the id of a
 | `width`     | Defines the width of the form element in 1/12 units of the total width. Effective on medium or larger devices. On small devices, the width is always 100%.                                                                                                                                                      |
 | `attributes`| Allows adding additional attributes for the generated input element (e.g., `min`, `max` for number inputs). Example usage: `attributes: {'min': 1, 'max': 10}`.                                                                                                                                                  |
 | `prepend`| Adds a visual element before the input field. This can be used for prefixes, labels, or other indicators. Example usage: prepend: 'Prefix' creates an input field with a preceding text or symbol. |
+| `disabled`| Starts the field disabled. The input is greyed out and cannot be edited until `field.enable()` is called. |
+| `hidden`| Starts the field hidden. It is left out of the layout until `field.show()` is called. The field still exists and submits its value. |
 
 
 ### **Simple input example**
@@ -57,6 +59,43 @@ The return value if `form.createField` is the created field. It has an attribute
 `form.addCustomHTML()`. With this you can add Html inside of the form.
 
 `form.addSeperator()`. This inserts a simple `<hr>` element at the end of the current builded form.
+
+### **Disabling fields**
+
+A field can be disabled and re-enabled at runtime. A disabled field is greyed out and cannot be edited, but still submits its value.
+
+```js
+field.disable();        // disable a single field
+field.enable();         // re-enable it
+field.isDisabled();     // true while disabled
+
+form.disable();         // disable the whole form (all fields + submit button)
+form.enable();          // re-enable it
+```
+
+`form.disable()` and a field's own `field.disable()` are independent: re-enabling the form does not re-enable a field that was disabled on its own. While a form is submitting it disables itself automatically and restores the previous state when the request finishes.
+
+### **Showing and hiding fields**
+
+Fields can be removed from and added back to the layout at runtime. A hidden field still exists and submits its value — it is just not rendered.
+
+```js
+field.hide();           // remove from the layout
+field.show();           // add it back in its original position
+field.isHidden();       // true while hidden
+```
+
+Custom HTML (`addCustomHTML`) and separators (`addSeperator`) keep their place when fields are shown or hidden. Do not mix `show()` / `hide()` with manual DOM manipulation of a field's wrapper (e.g. `$(field.dom).parent().hide()`) — the two will fight over the layout.
+
+### **Reading and writing all values**
+
+```js
+form.getValues();                       // { fieldName: value, ... }
+form.setValues({ first_name: "Ada" });  // set the named fields
+form.setValues(data, { resetUnknown: true }); // reset fields not present in data first
+```
+
+CED fields are skipped by `getValues` / `setValues`; their data round-trips through the normal submit instead.
 
 
 ## Back-end

--- a/docs/forms/auto-form-validation.md
+++ b/docs/forms/auto-form-validation.md
@@ -87,6 +87,13 @@ field.isHidden();       // true while hidden
 
 Custom HTML (`addCustomHTML`) and separators (`addSeperator`) keep their place when fields are shown or hidden. Do not mix `show()` / `hide()` with manual DOM manipulation of a field's wrapper (e.g. `$(field.dom).parent().hide()`) — the two will fight over the layout.
 
+The built-in submit button can be hidden too — useful for live forms that have no submit:
+
+```js
+form.hideSubmit();
+form.showSubmit();
+```
+
 ### **Reading and writing all values**
 
 ```js
@@ -96,6 +103,27 @@ form.setValues(data, { resetUnknown: true }); // reset fields not present in dat
 ```
 
 CED fields are skipped by `getValues` / `setValues`; their data round-trips through the normal submit instead.
+
+Keys passed to `setValues` that don't match any field are kept on `form.meta` and returned by `getValues`, but are never submitted to the backend. This lets a value like an id ride along with the form data:
+
+```js
+form.setValues({ first_name: "Ada", id: 42 }); // id has no field -> stored as meta
+form.getValues();                               // { first_name: "Ada", id: 42 }
+form.meta;                                      // { id: 42 }   (inspectable)
+```
+
+### **Live / client-only forms**
+
+With `collectOnly: true` the form never posts to the backend. Clicking the submit button hands the collected values (`getValues()`, meta included) straight to `saveHook` instead. Combined with `inputHook` — called with `getValues()` on every change — the form becomes a live value source you can wire into the page without a round-trip.
+
+```js
+var form = Z.Forms.create({
+    dom: "form",
+    collectOnly: true,                  // submit -> saveHook(getValues()), no POST
+    saveHook: (values) => { /* values incl. meta */ },
+    inputHook: (values) => { /* fires on every keystroke / select change */ },
+});
+```
 
 
 ## Back-end

--- a/tests/e2e/app/Controllers/FormController.php
+++ b/tests/e2e/app/Controllers/FormController.php
@@ -22,6 +22,25 @@
             return $res->render("form/interactions");
         }
 
+        // Fixture for the form-ergonomics feature set: enable/disable,
+        // show/hide, getValues/setValues, auto-disable-on-submit, plus the
+        // _updateLayout rebuild (addCustomHTML/addSeperator survival, row
+        // state, listener survival). No validation rules — submission always
+        // succeeds so the auto-disable window can be observed.
+        public function action_ergonomics(Request $req, Response $res) {
+            if($req->hasFormData()) {
+                $req->validateForm([
+                    (new FormField("field_a")),
+                    (new FormField("watched")),
+                    (new FormField("field_half")),
+                ]);
+
+                return $res->success();
+            }
+
+            return $res->render("form/ergonomics");
+        }
+
         // Probe for the integer() and exists() validation rules. The existing
         // form-fixture controllers don't exercise these. Validation runs on
         // every request (no GET-vs-POST split), and the result is emitted as

--- a/tests/e2e/app/Views/form/ergonomics.php
+++ b/tests/e2e/app/Views/form/ergonomics.php
@@ -9,6 +9,12 @@
     <!-- Second form with a CED, for the ZCED-stub / getValues-skip tests. -->
     <div id="ced-form" data-test="ced-form"></div>
 
+    <!-- Third form: collectOnly + inputHook (live, client-only). The hooks
+         mirror their payload into these markers for the spec to read. -->
+    <div id="live-form" data-test="live-form"></div>
+    <div data-test="live-mirror"></div>
+    <div data-test="saved-mirror"></div>
+
     <script>
         var form = Z.Forms.create({ dom: "form" });
 
@@ -75,5 +81,28 @@
                 { name: "label", type: "text" },
             ],
         });
+
+        // Live / client-only form: collectOnly routes submit to saveHook,
+        // inputHook fires on every change. Both mirror their payload.
+        var liveForm = Z.Forms.create({
+            dom: "live-form",
+            collectOnly: true,
+            inputHook: function(values) {
+                document.querySelector("[data-test=live-mirror]").innerText = JSON.stringify(values);
+            },
+            saveHook: function(values) {
+                document.querySelector("[data-test=saved-mirror]").innerText = JSON.stringify(values);
+            },
+        });
+        liveForm.createField({ name: "live_text", type: "text" });
+        liveForm.createField({
+            name: "live_select",
+            type: "select",
+            food: [
+                { value: "a", text: "A" },
+                { value: "b", text: "B" },
+            ],
+        });
+        $(liveForm.buttonSubmit).attr("data-test", "live-submit");
     </script>
 <?php }]; ?>

--- a/tests/e2e/app/Views/form/ergonomics.php
+++ b/tests/e2e/app/Views/form/ergonomics.php
@@ -1,0 +1,79 @@
+<?php return [ "body" => function($opt) { ?>
+    <div id="form" data-test="form"></div>
+
+    <!-- Listener-survival probes: incremented by the watched field's
+         handlers, asserted by the spec. -->
+    <div data-test="native-count">0</div>
+    <div data-test="jquery-count">0</div>
+
+    <!-- Second form with a CED, for the ZCED-stub / getValues-skip tests. -->
+    <div id="ced-form" data-test="ced-form"></div>
+
+    <script>
+        var form = Z.Forms.create({ dom: "form" });
+
+        form.createField({
+            name: "field_a",
+            type: "text",
+        });
+
+        form.createField({
+            name: "field_disabled",
+            type: "text",
+            disabled: true,
+        });
+
+        form.createField({
+            name: "field_hidden",
+            type: "text",
+            hidden: true,
+        });
+
+        // The watched field carries two listeners — one via the native
+        // Z.js field.on() API, one via jQuery on field.input — so the
+        // spec can prove BOTH styles survive a _updateLayout() rebuild.
+        var nativeCount = 0;
+        var jqueryCount = 0;
+        var watched = form.createField({
+            name: "watched",
+            type: "text",
+        });
+        watched.on("input", function() {
+            nativeCount++;
+            document.querySelector("[data-test=native-count]").innerText = nativeCount;
+        });
+        $(watched.input).on("input", function() {
+            jqueryCount++;
+            document.querySelector("[data-test=jquery-count]").innerText = jqueryCount;
+        });
+
+        // Interleaved non-field content — must survive a layout rebuild.
+        form.addCustomHTML('<span data-test="custom-marker">CUSTOM</span>');
+        form.addSeperator();
+
+        // Ends on a partial (width 6) row so a createField() issued after a
+        // rebuild lands in a stale/detached row if the row-state desync
+        // regressed.
+        form.createField({
+            name: "field_half",
+            type: "text",
+            width: 6,
+        });
+
+        $(form.buttonSubmit).attr("data-test", "submit-btn");
+
+        // CED form (separate, so the main form keeps doReload=false).
+        var cedForm = Z.Forms.create({ dom: "ced-form" });
+        cedForm.createField({
+            name: "ced_text",
+            type: "text",
+        });
+        cedForm.createCED({
+            name: "ced_items",
+            text: "Items",
+            fields: [
+                { name: "label", type: "text" },
+            ],
+        });
+    </script>
+<?php }]; ?>

--- a/tests/e2e/tests/cypress/e2e/form/ergonomics.cy.js
+++ b/tests/e2e/tests/cypress/e2e/form/ergonomics.cy.js
@@ -128,6 +128,76 @@ describe('Form Ergonomics', () => {
         });
     });
 
+    describe('Meta values (non-field keys)', () => {
+        it('setValues keeps a non-field key on form.meta and getValues returns it', () => {
+            cy.window().then((win) => {
+                win.form.setValues({ field_a: 'Ada', id: 42 });
+                const values = win.form.getValues();
+                expect(values).to.have.property('field_a', 'Ada');
+                expect(values).to.have.property('id', 42);
+                expect(win.form.meta).to.deep.eq({ id: 42 });
+            });
+            // The matching field was still populated.
+            cy.form('field_a').should('have.value', 'Ada');
+        });
+
+        it('meta is client-only — it is not submitted to the backend', () => {
+            cy.intercept('POST', '/Form/ergonomics').as('submit');
+
+            cy.window().then((win) => win.form.setValues({ field_a: 'Ada', id: 42 }));
+            cy.query('submit-btn').click();
+
+            cy.wait('@submit').then((interception) => {
+                // FormData body carries field_a but never the meta-only "id".
+                // Match the multipart field-name boundary so "id" doesn't
+                // accidentally match inside "field_hidden".
+                const body = interception.request.body;
+                expect(body).to.contain('name="field_a"');
+                expect(body).to.not.contain('name="id"');
+            });
+        });
+    });
+
+    describe('Submit button visibility', () => {
+        it('hideSubmit() hides the button, showSubmit() brings it back', () => {
+            cy.query('submit-btn').should('be.visible');
+
+            cy.window().then((win) => win.form.hideSubmit());
+            cy.query('submit-btn').should('not.be.visible');
+
+            cy.window().then((win) => win.form.showSubmit());
+            cy.query('submit-btn').should('be.visible');
+        });
+    });
+
+    describe('collectOnly (client-only submit)', () => {
+        it('submit hands getValues() to saveHook and never POSTs', () => {
+            cy.intercept('POST', '/Form/ergonomics').as('liveSubmit');
+
+            cy.get('#live-form').find('input[name=live_text]').type('hi');
+            cy.query('live-submit').click();
+
+            // saveHook fired with the collected values.
+            cy.query('saved-mirror').should('contain.text', '"live_text":"hi"');
+
+            // No request was made.
+            cy.get('@liveSubmit.all').should('have.length', 0);
+        });
+    });
+
+    describe('inputHook (live value changes)', () => {
+        it('fires with getValues() on every keystroke', () => {
+            cy.get('#live-form').find('input[name=live_text]').type('ab');
+            // Last keystroke leaves the full value in the mirror.
+            cy.query('live-mirror').should('contain.text', '"live_text":"ab"');
+        });
+
+        it('fires on a select change too', () => {
+            cy.get('#live-form').find('select[name=live_select]').select('b');
+            cy.query('live-mirror').should('contain.text', '"live_select":"b"');
+        });
+    });
+
     describe('Auto-disable during submit', () => {
         it('disables the submit button while the request is in flight, re-enables after', () => {
             cy.intercept('POST', '/Form/ergonomics', (req) => {

--- a/tests/e2e/tests/cypress/e2e/form/ergonomics.cy.js
+++ b/tests/e2e/tests/cypress/e2e/form/ergonomics.cy.js
@@ -1,0 +1,249 @@
+// Coverage for the form-ergonomics API (enable/disable, show/hide,
+// getValues/setValues, auto-disable-on-submit) plus the _updateLayout
+// rebuild guarantees: addCustomHTML/addSeperator content survives a
+// rebuild, the row state stays consistent so later createField() calls
+// render, and — most importantly — event listeners attached to fields
+// keep firing after a rebuild.
+
+describe('Form Ergonomics', () => {
+    before(() => {
+        cy.dbSeed();
+    });
+
+    beforeEach(() => {
+        cy.visit('/Form/ergonomics');
+    });
+
+    describe('Field disable / enable', () => {
+        it('options.disabled starts the field disabled', () => {
+            cy.form('field_disabled').should('be.disabled');
+            cy.window().then((win) => {
+                expect(win.form.fields.field_disabled.isDisabled()).to.eq(true);
+            });
+        });
+
+        it('field.disable() / enable() toggle the input', () => {
+            cy.form('field_a').should('not.be.disabled');
+
+            cy.window().then((win) => win.form.fields.field_a.disable());
+            cy.form('field_a').should('be.disabled');
+
+            cy.window().then((win) => {
+                expect(win.form.fields.field_a.isDisabled()).to.eq(true);
+                win.form.fields.field_a.enable();
+            });
+            cy.form('field_a').should('not.be.disabled');
+        });
+    });
+
+    describe('Field show / hide', () => {
+        it('options.hidden keeps the field out of the layout', () => {
+            cy.form('field_hidden').should('not.exist');
+            cy.window().then((win) => {
+                expect(win.form.fields.field_hidden.isHidden()).to.eq(true);
+            });
+        });
+
+        it('hide() removes the field and show() brings it back', () => {
+            cy.form('field_a').should('exist');
+
+            cy.window().then((win) => win.form.fields.field_a.hide());
+            cy.form('field_a').should('not.exist');
+
+            cy.window().then((win) => win.form.fields.field_a.show());
+            cy.form('field_a').should('exist').and('be.visible');
+        });
+
+        it('a field hidden from the start can be shown', () => {
+            cy.form('field_hidden').should('not.exist');
+            cy.window().then((win) => win.form.fields.field_hidden.show());
+            cy.form('field_hidden').should('exist').and('be.visible');
+        });
+    });
+
+    describe('Form disable / enable', () => {
+        it('form.disable() disables every field input and the submit button', () => {
+            cy.window().then((win) => win.form.disable());
+
+            cy.form('field_a').should('be.disabled');
+            cy.form('watched').should('be.disabled');
+            cy.form('field_half').should('be.disabled');
+            cy.query('submit-btn').should('be.disabled');
+
+            cy.window().then((win) => {
+                expect(win.form.isDisabled()).to.eq(true);
+                // A field reports disabled because the form is, even though
+                // its own flag is false.
+                expect(win.form.fields.field_a.isDisabled()).to.eq(true);
+            });
+        });
+
+        it('form.enable() re-enables fields but preserves a field disabled on its own', () => {
+            cy.window().then((win) => {
+                win.form.disable();
+                win.form.enable();
+            });
+
+            // field_a had no individual disable -> back to enabled.
+            cy.form('field_a').should('not.be.disabled');
+            // field_disabled was disabled on its own -> stays disabled.
+            cy.form('field_disabled').should('be.disabled');
+        });
+    });
+
+    describe('getValues / setValues', () => {
+        it('getValues returns a value per (non-CED) field', () => {
+            cy.form('field_a').type('hello');
+            cy.window().then((win) => {
+                const values = win.form.getValues();
+                expect(values).to.have.property('field_a', 'hello');
+                expect(values).to.have.property('watched');
+                expect(values).to.have.property('field_half');
+            });
+        });
+
+        it('setValues populates the named fields', () => {
+            cy.window().then((win) => {
+                win.form.setValues({ field_a: 'alpha', field_half: 'beta' });
+            });
+            cy.form('field_a').should('have.value', 'alpha');
+            cy.form('field_half').should('have.value', 'beta');
+        });
+
+        it('getValues omits CED fields entirely', () => {
+            cy.window().then((win) => {
+                const values = win.cedForm.getValues();
+                expect(values).to.have.property('ced_text');
+                expect(values).to.not.have.property('ced_items');
+            });
+        });
+
+        it('setValues ignores a CED key without throwing', () => {
+            cy.window().then((win) => {
+                expect(() =>
+                    win.cedForm.setValues({ ced_text: 'x', ced_items: [{ label: 'y' }] })
+                ).to.not.throw();
+            });
+            cy.get('#ced-form').find('input[name=ced_text]').should('have.value', 'x');
+        });
+    });
+
+    describe('Auto-disable during submit', () => {
+        it('disables the submit button while the request is in flight, re-enables after', () => {
+            cy.intercept('POST', '/Form/ergonomics', (req) => {
+                req.reply({ delay: 350, body: JSON.stringify({ result: 'success' }) });
+            }).as('submit');
+
+            cy.form('field_a').type('x');
+            cy.query('submit-btn').click();
+
+            // In-flight: button disabled.
+            cy.query('submit-btn').should('be.disabled');
+
+            cy.wait('@submit');
+
+            // Settled: button enabled again.
+            cy.query('submit-btn').should('not.be.disabled');
+        });
+    });
+
+    describe('_updateLayout preserves non-field content (regression: innerHTML wipe)', () => {
+        it('addCustomHTML content survives a layout rebuild triggered by hide()', () => {
+            cy.query('custom-marker').should('exist').and('contain.text', 'CUSTOM');
+            cy.get('#form hr').should('have.length', 1);
+
+            // Any show/hide rebuilds the whole layout.
+            cy.window().then((win) => win.form.fields.field_a.hide());
+
+            // Before the fix, _updateLayout did inputSpace.innerHTML = "" and
+            // these would be gone.
+            cy.query('custom-marker').should('exist').and('contain.text', 'CUSTOM');
+            cy.get('#form hr').should('have.length', 1);
+        });
+
+        it('custom content keeps its place across repeated hide/show cycles', () => {
+            cy.window().then((win) => {
+                win.form.fields.watched.hide();
+                win.form.fields.watched.show();
+                win.form.fields.field_a.hide();
+                win.form.fields.field_a.show();
+            });
+            cy.query('custom-marker').should('exist');
+            cy.get('#form hr').should('have.length', 1);
+        });
+    });
+
+    describe('_updateLayout keeps row state consistent (regression: stale currentRow)', () => {
+        it('a field created after a rebuild is still attached and visible', () => {
+            cy.window().then((win) => win.form.fields.field_a.hide());
+
+            cy.window().then((win) => {
+                win.form.createField({ name: 'late_field', type: 'text', width: 6 });
+            });
+
+            // Before the fix, this.currentRow pointed at a detached row after
+            // the rebuild, so the new field's DOM was appended off-document.
+            cy.form('late_field').should('exist').and('be.visible');
+            // And it really lives inside the rendered form, not limbo.
+            cy.get('#form').find('input[name=late_field]').should('have.length', 1);
+        });
+    });
+
+    describe('Event listeners survive layout rebuilds', () => {
+        it('native field.on() listener keeps firing after a sibling hide rebuilds the layout', () => {
+            cy.form('watched').type('a');
+            cy.query('native-count').should('have.text', '1');
+
+            // Hiding a DIFFERENT field rebuilds the whole layout, re-attaching
+            // the watched field's DOM.
+            cy.window().then((win) => win.form.fields.field_a.hide());
+
+            cy.form('watched').type('b');
+            cy.query('native-count').should('have.text', '2');
+        });
+
+        it('jQuery $(field.input).on() listener also keeps firing after a rebuild', () => {
+            cy.form('watched').type('a');
+            cy.query('jquery-count').should('have.text', '1');
+
+            cy.window().then((win) => win.form.fields.field_a.hide());
+
+            cy.form('watched').type('b');
+            cy.query('jquery-count').should('have.text', '2');
+        });
+
+        it('listeners survive hiding and re-showing the watched field itself', () => {
+            cy.form('watched').type('a');
+            cy.query('native-count').should('have.text', '1');
+            cy.query('jquery-count').should('have.text', '1');
+
+            cy.window().then((win) => {
+                win.form.fields.watched.hide();
+                win.form.fields.watched.show();
+            });
+
+            cy.form('watched').type('b');
+            cy.query('native-count').should('have.text', '2');
+            cy.query('jquery-count').should('have.text', '2');
+        });
+    });
+
+    describe('CED participates in form-level iterations without throwing', () => {
+        it('renders a form containing a CED (addField calls field.isHidden())', () => {
+            // If ZCED lacked the isHidden() stub the page would have thrown
+            // "field.isHidden is not a function" during createCED.
+            cy.get('#ced-form').find('input[name=ced_text]').should('exist');
+        });
+
+        it('form.disable() and reset() do not throw with a CED present', () => {
+            cy.window().then((win) => {
+                expect(() => win.cedForm.disable()).to.not.throw();
+                expect(() => win.cedForm.enable()).to.not.throw();
+                expect(() => win.cedForm.reset()).to.not.throw();
+            });
+            // The plain field still disabled/enabled as normal.
+            cy.window().then((win) => win.cedForm.disable());
+            cy.get('#ced-form').find('input[name=ced_text]').should('be.disabled');
+        });
+    });
+});

--- a/web/Z.js
+++ b/web/Z.js
@@ -1034,6 +1034,14 @@ class ZForm {
  */
 class ZFormField {
 
+  get value() {
+    return this.input.value;
+  }
+
+  set value(value) {
+    this.input.value = value;
+  }
+
   /**
    * Creates a new form Field. Usally this called from ZForm.createField and not directly
    * @param {FormFieldOptions} options Options for this field

--- a/web/Z.js
+++ b/web/Z.js
@@ -1003,6 +1003,14 @@ class ZForm {
  */
 class ZFormField {
 
+  get value() {
+    return this.input.value;
+  }
+
+  set value(value) {
+    this.input.value = value;
+  }
+
   /**
    * Creates a new form Field. Usally this called from ZForm.createField and not directly
    * @param {FormFieldOptions} options Options for this field

--- a/web/Z.js
+++ b/web/Z.js
@@ -769,6 +769,33 @@ class ZForm {
   }
 
   /**
+   * Returns an object where each key is the fieldname with its value as value
+   * @returns {{[fieldName: string]: any}}
+   */
+  getValues() {
+    return Object.fromEntries(
+      Object.entries(this.fields).map(([fieldName, field]) => [fieldName, field.value])
+    )
+  }
+
+  /**
+   * Fills a form with a data object
+   * @param {{[fieldName: string]: any}} data 
+   * @param {Object} options
+   * @param {boolean} [options.resetUnknown] Reset fields which values are not in data?
+   */
+  setValues(data, options = {}) {
+    if (options.resetUnknown) {
+      this.reset()
+    }
+
+    for (const fieldName in data) {
+      if (!(fieldName in this.fields)) continue
+      this.fields[fieldName].value = data[fieldName]
+    }
+  }
+
+  /**
    * Adds custom html to the current part of the Form
    * @returns {void}
    */

--- a/web/Z.js
+++ b/web/Z.js
@@ -731,6 +731,11 @@ class ZForm {
     this.currentRow = null;
     this.rows = [];
 
+    /**
+     * @private
+     */
+    this._isDisabled = false;
+
     if (options.dom) document.getElementById(options.dom).appendChild(this.dom);
   }
 
@@ -811,6 +816,7 @@ class ZForm {
     if (this.lastSendAt && now - this.lastSendAt < 300) return;
     this.lastSendAt = now;
     this.isSending = true;
+    this._updateDisabled();
 
     var data = this.getFormData();
 
@@ -862,6 +868,7 @@ class ZForm {
 
     }).always(() => {
       this.isSending = false;
+      this._updateDisabled();
     });
   }
 
@@ -914,7 +921,8 @@ class ZForm {
    * @returns {ZFormField} The newly created field
    */
   createField(options) {
-    var field = new ZFormField(options);
+    const field = new ZFormField(options);
+    field.form = this;
     this.addField(field);
     return field;
   }
@@ -985,6 +993,41 @@ class ZForm {
     }
   }
 
+  /**
+   * Enables the form
+   */
+  enable() {
+    this._isDisabled = false;
+    this._updateDisabled();
+
+  }
+
+  /**
+   * Disables the form
+   */
+  disable() {
+    this._isDisabled = true;
+    this._updateDisabled();
+  }
+
+  /**
+   * @returns {boolean} True when form is disabled
+   */
+  isDisabled() {
+    if (this.isSending) return true
+    return this._isDisabled;
+  }
+
+  /**
+   * @private
+   */
+  _updateDisabled() {
+    for (const field of Object.values(this.fields)) {
+      field._updateDisabled();
+    }
+    this.buttonSubmit.disabled = this.isDisabled();
+  }
+
 }
 
 /**
@@ -1009,19 +1052,20 @@ class ZForm {
 /**
  * All parameters are optional
  * @typedef FormFieldOptions
- * @property {string} name Name to use in the request
- * @property {boolean} required Sets if this field is required to be filled in
- * @property {InputType} type Type of the field
- * @property {string} text Text to show in the label
- * @property {string} hint Small text to show under the input. For example: "We do not share you email" or something.
- * @property {any} default Default value 
- * @property {boolean} autofill Enable browser level autofill for this field.
- * @property {string} placeholder Placeholder to show in the input when nothing is entered
- * @property {FieldWidth} width Width of the field in units
- * @property {object} attributes List of attributes to apply to the input element. The keys are attribute names and their values will be used as the value
- * @property {Food} food Food for selects or autocomepletes
- * @property {boolean} compact Sets the compact mode. In compact mode, the label is hidden
- * @property {string} prepend Content to put in front of the input. Units are usally put there
+ * @property {string} [name] Name to use in the request
+ * @property {boolean} [required] Sets if this field is required to be filled in
+ * @property {InputType} [type] Type of the field
+ * @property {string} [text] Text to show in the label
+ * @property {string} [hint] Small text to show under the input. For example: "We do not share you email" or something.
+ * @property {any} [default] Default value 
+ * @property {boolean} [autofill] Enable browser level autofill for this field.
+ * @property {string} [placeholder] Placeholder to show in the input when nothing is entered
+ * @property {FieldWidth} [width] Width of the field in units
+ * @property {object} [attributes] List of attributes to apply to the input element. The keys are attribute names and their values will be used as the value
+ * @property {Food} [food] Food for selects or autocomepletes
+ * @property {boolean} [compact] Sets the compact mode. In compact mode, the label is hidden
+ * @property {string} [prepend] Content to put in front of the input. Units are usally put there
+ * @property {boolean} [disabled] Does this field start disabled?
  */
 
 /**
@@ -1050,6 +1094,17 @@ class ZFormField {
     this.autocompleteMinCharacters = options.autocompleteMinCharacters || 2;
     this.autocompleteTextCB = options.autocompleteTextCB;
     this.autocompleteCB = options.autocompleteCB || null;
+
+    /**
+     * @type {ZForm|null}
+     */
+    this.form = null;
+
+    /**
+     * @private
+     * Was this field disabled manually?
+     */
+    this._isDisabled = false
 
     this.optgroup = null;
 
@@ -1253,6 +1308,10 @@ class ZFormField {
     if (options.compact) {
       this.label.classList.add("d-none");
     }
+
+    if (options.disabled) {
+      this.disable();
+    }
   }
 
   /**
@@ -1397,5 +1456,36 @@ class ZFormField {
    */
   reset() {
     this.input.value = this.default ?? "";
+  }
+
+  /**
+   * Disables the form field
+   */
+  disable() {
+    this._isDisabled = true;
+    this._updateDisabled();
+  }
+
+  /**
+   * Enables the form field
+   */
+  enable() {
+    this._isDisabled = false;
+    this._updateDisabled();
+  }
+
+  isDisabled() {
+    if (this.form) {
+      if (this.form.isDisabled()) return true;
+    }
+
+    return this._isDisabled;
+  }
+
+  /**
+   * @private
+   */
+  _updateDisabled() {
+    this.input.disabled = this.isDisabled();
   }
 }

--- a/web/Z.js
+++ b/web/Z.js
@@ -765,6 +765,33 @@ class ZForm {
   }
 
   /**
+   * Returns an object where each key is the fieldname with its value as value
+   * @returns {{[fieldName: string]: any}}
+   */
+  getValues() {
+    return Object.fromEntries(
+      Object.entries(this.fields).map(([fieldName, field]) => [fieldName, field.value])
+    )
+  }
+
+  /**
+   * Fills a form with a data object
+   * @param {{[fieldName: string]: any}} data 
+   * @param {Object} options
+   * @param {boolean} [options.resetUnknown] Reset fields which values are not in data?
+   */
+  setValues(data, options = {}) {
+    if (options.resetUnknown) {
+      this.reset()
+    }
+
+    for (const fieldName in data) {
+      if (!(fieldName in this.fields)) continue
+      this.fields[fieldName].value = data[fieldName]
+    }
+  }
+
+  /**
    * Adds custom html to the current part of the Form
    * @returns {void}
    */

--- a/web/Z.js
+++ b/web/Z.js
@@ -1003,14 +1003,6 @@ class ZForm {
  */
 class ZFormField {
 
-  get value() {
-    return this.input.value;
-  }
-
-  set value(value) {
-    this.input.value = value;
-  }
-
   /**
    * Creates a new form Field. Usally this called from ZForm.createField and not directly
    * @param {FormFieldOptions} options Options for this field

--- a/web/Z.js
+++ b/web/Z.js
@@ -1104,7 +1104,6 @@ class ZForm {
   enable() {
     this._isDisabled = false;
     this._updateDisabled();
-
   }
 
   /**
@@ -1217,13 +1216,13 @@ class ZFormField {
      * @private
      * Was this field disabled manually?
      */
-    this._isDisabled = false
+    this._isDisabled = false;
 
     /**
      * @private
      * Is this field hidden?
      */
-    this._isHidden = false
+    this._isHidden = false;
 
     this.optgroup = null;
 
@@ -1778,17 +1777,16 @@ class ZFormField {
   }
 
   hide() {
-    this._isHidden = true
+    this._isHidden = true;
     if (this.form) this.form._updateLayout();
   }
 
   show() {
-    this._isHidden = false
+    this._isHidden = false;
     if (this.form) this.form._updateLayout();
   }
 
   isHidden() {
-    // Logic for conditional fields would be here when implemented
-    return this._isHidden
+    return this._isHidden;
   }
 }

--- a/web/Z.js
+++ b/web/Z.js
@@ -735,6 +735,11 @@ class ZForm {
     this.currentRow = null;
     this.rows = [];
 
+    /**
+     * @private
+     */
+    this._isDisabled = false;
+
     if (options.dom) document.getElementById(options.dom).appendChild(this.dom);
   }
 
@@ -815,6 +820,7 @@ class ZForm {
     if (this.lastSendAt && now - this.lastSendAt < 300) return;
     this.lastSendAt = now;
     this.isSending = true;
+    this._updateDisabled();
 
     var data = this.getFormData();
 
@@ -866,6 +872,7 @@ class ZForm {
 
     }).always(() => {
       this.isSending = false;
+      this._updateDisabled();
     });
   }
 
@@ -938,7 +945,8 @@ class ZForm {
    * @returns {ZFormField} The newly created field
    */
   createField(options) {
-    var field = new ZFormField(options);
+    const field = new ZFormField(options);
+    field.form = this;
     this.addField(field);
     return field;
   }
@@ -1009,6 +1017,41 @@ class ZForm {
     }
   }
 
+  /**
+   * Enables the form
+   */
+  enable() {
+    this._isDisabled = false;
+    this._updateDisabled();
+
+  }
+
+  /**
+   * Disables the form
+   */
+  disable() {
+    this._isDisabled = true;
+    this._updateDisabled();
+  }
+
+  /**
+   * @returns {boolean} True when form is disabled
+   */
+  isDisabled() {
+    if (this.isSending) return true
+    return this._isDisabled;
+  }
+
+  /**
+   * @private
+   */
+  _updateDisabled() {
+    for (const field of Object.values(this.fields)) {
+      field._updateDisabled();
+    }
+    this.buttonSubmit.disabled = this.isDisabled();
+  }
+
 }
 
 /**
@@ -1053,6 +1096,7 @@ class ZForm {
  * @property {number} [autocompleteMinCharacters] Minimum number of characters typed before autocomplete fetches/filters suggestions. Defaults to `2`.
  * @property {function} [autocompleteTextCB] Callback `(item) => string` mapping an autocomplete entry to its rendered list label. Defaults to the entry's `text` property.
  * @property {function} [autocompleteCB] Callback `(item) => void` fired when the user picks an entry from the autocomplete list.
+ * @property {boolean} [disabled] Does this field start disabled?
  */
 
 /**
@@ -1081,6 +1125,17 @@ class ZFormField {
     this.autocompleteMinCharacters = options.autocompleteMinCharacters || 2;
     this.autocompleteTextCB = options.autocompleteTextCB;
     this.autocompleteCB = options.autocompleteCB || null;
+
+    /**
+     * @type {ZForm|null}
+     */
+    this.form = null;
+
+    /**
+     * @private
+     * Was this field disabled manually?
+     */
+    this._isDisabled = false
 
     this.optgroup = null;
 
@@ -1310,6 +1365,10 @@ class ZFormField {
 
     if (options.compact) {
       this.label.classList.add("d-none");
+    }
+
+    if (options.disabled) {
+      this.disable();
     }
   }
 
@@ -1595,5 +1654,36 @@ class ZFormField {
       return;
     }
     this.input.value = this.default ?? "";
+  }
+
+  /**
+   * Disables the form field
+   */
+  disable() {
+    this._isDisabled = true;
+    this._updateDisabled();
+  }
+
+  /**
+   * Enables the form field
+   */
+  enable() {
+    this._isDisabled = false;
+    this._updateDisabled();
+  }
+
+  isDisabled() {
+    if (this.form) {
+      if (this.form.isDisabled()) return true;
+    }
+
+    return this._isDisabled;
+  }
+
+  /**
+   * @private
+   */
+  _updateDisabled() {
+    this.input.disabled = this.isDisabled();
   }
 }

--- a/web/Z.js
+++ b/web/Z.js
@@ -465,6 +465,18 @@ class ZCED { //Create, edit, delete
       this.items[this.items.length - 1].dom.classList.remove("mb-1");
     }
   }
+
+  /**
+   * Compatibility stubs so a CED participates in ZForm's per-field
+   * iterations (addField visibility skip, _updateDisabled, reset).
+   * CEDs don't currently support being hidden or disabled as a unit —
+   * these no-ops keep the form-level machinery from throwing when
+   * iterating mixed fields.
+   */
+  isHidden() { return false; }
+  isDisabled() { return false; }
+  _updateDisabled() { /* no-op */ }
+  reset() { /* no-op */ }
 }
 
 /**

--- a/web/Z.js
+++ b/web/Z.js
@@ -705,12 +705,14 @@ class ZForm {
    * @param {boolean} [options.hidehints] Suppress the inline hint banner (saved / unsaved / error). Defaults to `false` (hints are shown).
    * @param {boolean} [options.sendOnSubmitClick] If `false`, the built-in submit button no longer calls `send()` automatically — the caller is responsible for triggering submission. Defaults to `true`.
    * @param {string} [options.customEndpoint] Override the URL `send()` posts to. By default the form posts back to the current action.
+   * @param {boolean} [options.collectOnly] Client-only mode: the submit button never posts to the backend. Instead it hands the collected values (`getValues()`) to `saveHook`. Defaults to `false`.
+   * @param {function} [options.inputHook] Called with `getValues()` on every field change (typing, selecting, etc). Lets the form be consumed live without a submit.
    */
   constructor(options = {
-    doReload: true, 
-    dom: null, 
-    saveHook: null, 
-    formErrorHook:null, 
+    doReload: true,
+    dom: null,
+    saveHook: null,
+    formErrorHook:null,
     hidehints: false,
     sendOnSubmitClick: true,
     customEndpoint: null
@@ -724,6 +726,16 @@ class ZForm {
     this.formErrorHook = options.formErrorHook;
     this.sendOnSubmitClick = "sendOnSubmitClick" in options ? options.sendOnSubmitClick : true;
     this.customEndpoint = options.customEndpoint || null;
+    this.collectOnly = options.collectOnly || false;
+    this.inputHook = options.inputHook || null;
+
+    /**
+     * Client-only metadata carried alongside the form values. Keys passed
+     * to setValues() that don't match a field land here and are returned by
+     * getValues(), but are never submitted to the backend — handy for an id
+     * or other context attached to the record being edited.
+     */
+    this.meta = {};
 
     this.hidehints = options.hidehints;
 
@@ -740,6 +752,10 @@ class ZForm {
     this.dom.appendChild(this.inputSpace);
 
     this.buttonSubmit = this.createActionButton(Z.Lang.submit, "btn-primary", () => {
+      if(this.collectOnly) {
+        if(this.saveHook) this.saveHook(this.getValues());
+        return;
+      }
       if(this.sendOnSubmitClick) this.send(this.customEndpoint);
     });
 
@@ -795,21 +811,28 @@ class ZForm {
   }
 
   /**
-   * Returns an object where each key is the fieldname with its value as value.
-   * CEDs are skipped: they have no scalar value and round-trip through
+   * Returns an object of the form's values: every (non-CED) field's value,
+   * merged with any client-only `meta` carried via setValues(). CEDs are
+   * skipped — they have no scalar value and round-trip through
    * getFormData / getPostString instead.
    * @returns {{[fieldName: string]: any}}
    */
   getValues() {
-    return Object.fromEntries(
-      Object.entries(this.fields)
-        .filter(([, field]) => field.type !== "CED")
-        .map(([fieldName, field]) => [fieldName, field.value])
-    );
+    return {
+      ...this.meta,
+      ...Object.fromEntries(
+        Object.entries(this.fields)
+          .filter(([, field]) => field.type !== "CED")
+          .map(([fieldName, field]) => [fieldName, field.value])
+      )
+    };
   }
 
   /**
-   * Fills a form with a data object. CEDs are skipped (see getValues).
+   * Fills a form with a data object. Keys matching a field set that field's
+   * value; keys matching no field are kept in `this.meta` (client-only,
+   * never submitted) so values like an id can ride along. CED keys are
+   * skipped.
    * @param {{[fieldName: string]: any}} data
    * @param {Object} options
    * @param {boolean} [options.resetUnknown] Reset fields which values are not in data?
@@ -820,9 +843,13 @@ class ZForm {
     }
 
     for (const fieldName in data) {
-      if (!(fieldName in this.fields)) continue;
-      if (this.fields[fieldName].type === "CED") continue;
-      this.fields[fieldName].value = data[fieldName];
+      const field = this.fields[fieldName];
+      if (field) {
+        if (field.type === "CED") continue;
+        field.value = data[fieldName];
+      } else {
+        this.meta[fieldName] = data[fieldName];
+      }
     }
   }
 
@@ -916,11 +943,12 @@ class ZForm {
     field.form = this;
 
     this.fields[field.name] = field;
-    var showUnsavedHint = () => {
+    var onFieldChange = () => {
       this.hint("alert-warning", Z.Lang.unsaved);
+      if (this.inputHook) this.inputHook(this.getValues());
     };
-    field.on('input', showUnsavedHint);
-    field.on('change', showUnsavedHint);
+    field.on('input', onFieldChange);
+    field.on('change', onFieldChange);
     bsCustomFileInput.init();
 
     this.items.push({type: "field", field: field});
@@ -1086,6 +1114,23 @@ class ZForm {
     this.dom.appendChild(button);
     button.addEventListener("click", action);
     return button;
+  }
+
+  /**
+   * Hides the built-in submit button. Useful for collectOnly / live forms
+   * that are consumed via inputHook and don't need a submit.
+   * @returns {void}
+   */
+  hideSubmit() {
+    this.buttonSubmit.style.display = "none";
+  }
+
+  /**
+   * Shows the built-in submit button again.
+   * @returns {void}
+   */
+  showSubmit() {
+    this.buttonSubmit.style.display = "";
   }
 
   /**

--- a/web/Z.js
+++ b/web/Z.js
@@ -1034,14 +1034,6 @@ class ZForm {
  */
 class ZFormField {
 
-  get value() {
-    return this.input.value;
-  }
-
-  set value(value) {
-    this.input.value = value;
-  }
-
   /**
    * Creates a new form Field. Usally this called from ZForm.createField and not directly
    * @param {FormFieldOptions} options Options for this field

--- a/web/Z.js
+++ b/web/Z.js
@@ -1469,10 +1469,8 @@ class ZFormField {
     badge.setAttribute("data-value", value);
     badge.innerHTML = "&times; " + text;
     badge.addEventListener("click", () => {
-      // Honor PR 143's field.disable() — a disabled multi-select must not
-      // let badges be removed either. typeof-guarded so this still works
-      // pre-PR-143.
-      if (typeof this.isDisabled === "function" && this.isDisabled()) return;
+      // A disabled multi-select must not let badges be removed either.
+      if (this.isDisabled()) return;
 
       var idx = this.selectedValues.indexOf(value);
       if (idx >= 0) this.selectedValues.splice(idx, 1);

--- a/web/Z.js
+++ b/web/Z.js
@@ -883,6 +883,7 @@ class ZForm {
    */
   addField(field) {
     if (field.type == "CED") this.doReload = true;
+    field.form = this;
 
     this.fields[field.name] = field;
     var showUnsavedHint = () => {
@@ -891,6 +892,8 @@ class ZForm {
     field.on('input', showUnsavedHint);
     field.on('change', showUnsavedHint);
     bsCustomFileInput.init();
+
+    if (field.isHidden()) return;
 
     if (field.width + this.currentRowLength > 12) {
       var group = document.createElement("div");
@@ -906,6 +909,39 @@ class ZForm {
       this.currentRow.appendChild(field.dom);
     }
     this.currentRowLength += field.width;
+  }
+
+  /**
+   * Rebuilds the whole form layout. Should be executed when visibility of fields changes.
+   * It is not used when fields are added because it could potentially break existing userspace code, that handles field visibility.
+   * @private
+   */
+  _updateLayout() {
+    for (const field of Object.values(this.fields)) {
+      field.dom.remove()
+    }
+
+    this.inputSpace.innerHTML = ""
+
+    let currentLength = Infinity
+    let currentRow = null
+
+    for (const field of Object.values(this.fields)) {
+      if (field.isHidden()) continue;
+
+      if (field.width + currentLength > 12) {
+        const group = document.createElement("div");
+        group.classList.add("form-group");
+        currentRow = document.createElement("div");
+        currentRow.classList.add("form-row");
+        group.appendChild(currentRow);
+        this.inputSpace.appendChild(group);
+        currentLength = 0;
+      }
+
+      currentRow.appendChild(field.dom);
+      currentLength += field.width;
+    }
   }
 
   /**
@@ -946,7 +982,6 @@ class ZForm {
    */
   createField(options) {
     const field = new ZFormField(options);
-    field.form = this;
     this.addField(field);
     return field;
   }
@@ -1097,6 +1132,7 @@ class ZForm {
  * @property {function} [autocompleteTextCB] Callback `(item) => string` mapping an autocomplete entry to its rendered list label. Defaults to the entry's `text` property.
  * @property {function} [autocompleteCB] Callback `(item) => void` fired when the user picks an entry from the autocomplete list.
  * @property {boolean} [disabled] Does this field start disabled?
+ * @property {boolean} [hidden] Does this field start hidden?
  */
 
 /**
@@ -1136,6 +1172,12 @@ class ZFormField {
      * Was this field disabled manually?
      */
     this._isDisabled = false
+
+    /**
+     * @private
+     * Is this field hidden?
+     */
+    this._isHidden = false
 
     this.optgroup = null;
 
@@ -1369,6 +1411,10 @@ class ZFormField {
 
     if (options.disabled) {
       this.disable();
+    }
+
+    if (options.hidden) {
+      this.hide();
     }
   }
 
@@ -1685,5 +1731,20 @@ class ZFormField {
    */
   _updateDisabled() {
     this.input.disabled = this.isDisabled();
+  }
+
+  hide() {
+    this._isHidden = true
+    if (this.form) this.form._updateLayout();
+  }
+
+  show() {
+    this._isHidden = false
+    if (this.form) this.form._updateLayout();
+  }
+
+  isHidden() {
+    // Logic for conditional fields would be here when implemented
+    return this._isHidden
   }
 }

--- a/web/Z.js
+++ b/web/Z.js
@@ -468,10 +468,10 @@ class ZCED { //Create, edit, delete
 
   /**
    * Compatibility stubs so a CED participates in ZForm's per-field
-   * iterations (addField visibility skip, _updateDisabled, reset).
-   * CEDs don't currently support being hidden or disabled as a unit —
-   * these no-ops keep the form-level machinery from throwing when
-   * iterating mixed fields.
+   * iterations (addField visibility skip, _updateDisabled, getValues,
+   * setValues, reset). CEDs don't currently support being hidden or
+   * disabled as a unit — these are no-ops that keep the form-level
+   * machinery from throwing when iterating mixed fields.
    */
   isHidden() { return false; }
   isDisabled() { return false; }
@@ -749,6 +749,15 @@ class ZForm {
 
     /**
      * @private
+     * Ordered record of every top-level item added to the form (fields,
+     * custom HTML, separators, empty spacers). _updateLayout() iterates
+     * this list to rebuild the layout from scratch without dropping any
+     * non-field content.
+     */
+    this.items = [];
+
+    /**
+     * @private
      */
     this._isDisabled = false;
 
@@ -813,13 +822,17 @@ class ZForm {
   }
 
   /**
-   * Adds custom html to the current part of the Form
+   * Adds custom html to the current part of the Form. Breaks the current
+   * row so any field added afterwards starts on a fresh row below.
    * @returns {void}
    */
   addCustomHTML(html) {
     var node = document.createElement("div");
     node.innerHTML = html;
+    this.items.push({type: "html", node: node});
     this.inputSpace.appendChild(node);
+    this.currentRow = null;
+    this.currentRowLength = 12;
   }
 
   /**
@@ -905,8 +918,20 @@ class ZForm {
     field.on('change', showUnsavedHint);
     bsCustomFileInput.init();
 
+    this.items.push({type: "field", field: field});
+
     if (field.isHidden()) return;
 
+    this._appendFieldToLayout(field);
+  }
+
+  /**
+   * Appends a single visible field to the live layout, creating a new
+   * row/group when the current row would overflow. Shared by addField()
+   * (initial build) and _updateLayout() (rebuild on visibility change).
+   * @private
+   */
+  _appendFieldToLayout(field) {
     if (field.width + this.currentRowLength > 12) {
       var group = document.createElement("div");
       group.classList.add("form-group");
@@ -926,33 +951,29 @@ class ZForm {
   /**
    * Rebuilds the whole form layout. Should be executed when visibility of fields changes.
    * It is not used when fields are added because it could potentially break existing userspace code, that handles field visibility.
+   *
+   * Replays this.items in insertion order so addCustomHTML / addSeperator /
+   * createEmpty nodes survive the rebuild — wiping inputSpace would drop
+   * them otherwise. Also resets the instance row state so a subsequent
+   * createField() lands in the right place.
    * @private
    */
   _updateLayout() {
-    for (const field of Object.values(this.fields)) {
-      field.dom.remove()
-    }
+    this.inputSpace.innerHTML = "";
+    this.currentRow = null;
+    this.currentRowLength = 12;
 
-    this.inputSpace.innerHTML = ""
-
-    let currentLength = Infinity
-    let currentRow = null
-
-    for (const field of Object.values(this.fields)) {
-      if (field.isHidden()) continue;
-
-      if (field.width + currentLength > 12) {
-        const group = document.createElement("div");
-        group.classList.add("form-group");
-        currentRow = document.createElement("div");
-        currentRow.classList.add("form-row");
-        group.appendChild(currentRow);
-        this.inputSpace.appendChild(group);
-        currentLength = 0;
+    for (const item of this.items) {
+      if (item.type === "field") {
+        if (item.field.isHidden()) continue;
+        this._appendFieldToLayout(item.field);
+      } else {
+        // Custom HTML, separators, and empty spacers are re-attached as-is
+        // and break the current row so following fields start fresh.
+        this.inputSpace.appendChild(item.node);
+        this.currentRow = null;
+        this.currentRowLength = 12;
       }
-
-      currentRow.appendChild(field.dom);
-      currentLength += field.width;
     }
   }
 
@@ -1006,15 +1027,23 @@ class ZForm {
   createEmpty(size = 12) {
     var div = document.createElement("div");
     div.classList.add("col-0", "col-md-" + size);
+    this.items.push({type: "empty", node: div});
     this.inputSpace.appendChild(div);
+    this.currentRow = null;
+    this.currentRowLength = 12;
   }
 
   /**
-   * Adds an <hr> tag at the end of the generated form
+   * Adds an <hr> tag at the end of the generated form. Breaks the current
+   * row so any field added afterwards starts on a fresh row below.
    * @returns {void}
    */
   addSeperator() {
-    this.inputSpace.appendChild(document.createElement("hr"));
+    var node = document.createElement("hr");
+    this.items.push({type: "separator", node: node});
+    this.inputSpace.appendChild(node);
+    this.currentRow = null;
+    this.currentRowLength = 12;
   }
 
   /**

--- a/web/Z.js
+++ b/web/Z.js
@@ -879,6 +879,7 @@ class ZForm {
    */
   addField(field) {
     if (field.type == "CED") this.doReload = true;
+    field.form = this;
 
     this.fields[field.name] = field;
     var showUnsavedHint = () => {
@@ -887,6 +888,8 @@ class ZForm {
     field.on('input', showUnsavedHint);
     field.on('change', showUnsavedHint);
     bsCustomFileInput.init();
+
+    if (field.isHidden()) return;
 
     if (field.width + this.currentRowLength > 12) {
       var group = document.createElement("div");
@@ -902,6 +905,39 @@ class ZForm {
       this.currentRow.appendChild(field.dom);
     }
     this.currentRowLength += field.width;
+  }
+
+  /**
+   * Rebuilds the whole form layout. Should be executed when visibility of fields changes.
+   * It is not used when fields are added because it could potentially break existing userspace code, that handles field visibility.
+   * @private
+   */
+  _updateLayout() {
+    for (const field of Object.values(this.fields)) {
+      field.dom.remove()
+    }
+
+    this.inputSpace.innerHTML = ""
+
+    let currentLength = Infinity
+    let currentRow = null
+
+    for (const field of Object.values(this.fields)) {
+      if (field.isHidden()) continue;
+
+      if (field.width + currentLength > 12) {
+        const group = document.createElement("div");
+        group.classList.add("form-group");
+        currentRow = document.createElement("div");
+        currentRow.classList.add("form-row");
+        group.appendChild(currentRow);
+        this.inputSpace.appendChild(group);
+        currentLength = 0;
+      }
+
+      currentRow.appendChild(field.dom);
+      currentLength += field.width;
+    }
   }
 
   /**
@@ -922,7 +958,6 @@ class ZForm {
    */
   createField(options) {
     const field = new ZFormField(options);
-    field.form = this;
     this.addField(field);
     return field;
   }
@@ -1066,6 +1101,7 @@ class ZForm {
  * @property {boolean} [compact] Sets the compact mode. In compact mode, the label is hidden
  * @property {string} [prepend] Content to put in front of the input. Units are usally put there
  * @property {boolean} [disabled] Does this field start disabled?
+ * @property {boolean} [hidden] Does this field start hidden?
  */
 
 /**
@@ -1105,6 +1141,12 @@ class ZFormField {
      * Was this field disabled manually?
      */
     this._isDisabled = false
+
+    /**
+     * @private
+     * Is this field hidden?
+     */
+    this._isHidden = false
 
     this.optgroup = null;
 
@@ -1312,6 +1354,10 @@ class ZFormField {
     if (options.disabled) {
       this.disable();
     }
+
+    if (options.hidden) {
+      this.hide();
+    }
   }
 
   /**
@@ -1487,5 +1533,20 @@ class ZFormField {
    */
   _updateDisabled() {
     this.input.disabled = this.isDisabled();
+  }
+
+  hide() {
+    this._isHidden = true
+    if (this.form) this.form._updateLayout();
+  }
+
+  show() {
+    this._isHidden = false
+    if (this.form) this.form._updateLayout();
+  }
+
+  isHidden() {
+    // Logic for conditional fields would be here when implemented
+    return this._isHidden
   }
 }

--- a/web/Z.js
+++ b/web/Z.js
@@ -795,29 +795,34 @@ class ZForm {
   }
 
   /**
-   * Returns an object where each key is the fieldname with its value as value
+   * Returns an object where each key is the fieldname with its value as value.
+   * CEDs are skipped: they have no scalar value and round-trip through
+   * getFormData / getPostString instead.
    * @returns {{[fieldName: string]: any}}
    */
   getValues() {
     return Object.fromEntries(
-      Object.entries(this.fields).map(([fieldName, field]) => [fieldName, field.value])
-    )
+      Object.entries(this.fields)
+        .filter(([, field]) => field.type !== "CED")
+        .map(([fieldName, field]) => [fieldName, field.value])
+    );
   }
 
   /**
-   * Fills a form with a data object
-   * @param {{[fieldName: string]: any}} data 
+   * Fills a form with a data object. CEDs are skipped (see getValues).
+   * @param {{[fieldName: string]: any}} data
    * @param {Object} options
    * @param {boolean} [options.resetUnknown] Reset fields which values are not in data?
    */
   setValues(data, options = {}) {
     if (options.resetUnknown) {
-      this.reset()
+      this.reset();
     }
 
     for (const fieldName in data) {
-      if (!(fieldName in this.fields)) continue
-      this.fields[fieldName].value = data[fieldName]
+      if (!(fieldName in this.fields)) continue;
+      if (this.fields[fieldName].type === "CED") continue;
+      this.fields[fieldName].value = data[fieldName];
     }
   }
 


### PR DESCRIPTION
Form fields can now individually be enabled/disabled using `field.enable()` and `field.disable()` The current state can be retrieved using `field.isDisabled()`
Form fields can now be hidden/shown using `field.show()` and `field.hide()`. The current state can be retrieved using `field.isHidden()`

A whole form can now be enabled/disabled using `form.enable()` and `form.disable()`. The disabled state of the form fields is preserved and not overwritten by this. A form field is only enabled when the form and the field are enabled both at the same time. The state can be retrieved using `form.isDisabled()`

While submitting, the form is disabled automatically. This does not overwrite the disabled state set from userspace code.

`form.createField(options)` now has two more options:
* `disabled` is a boolean that determines if the field should be disabled from the start
* `hidden` is a boolean that determines if the field should be hidden from the start

using the `hide()` and `show()` method could break userspace implementations that do visibility handling manually. They are are never called internally, so this should only be a problem when the user opts in by using these methods.

All data in a form can now be retrieved as a single object using `form.getValues()` and set from a single object using `form.setValues(values)`