### PR TITLE
ci+docs: introduce develop branch and reduce PR PHP matrix

### DIFF
--- a/.github/workflows/tests_e2e.yml
+++ b/.github/workflows/tests_e2e.yml
@@ -39,14 +39,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php_tag: [
-          "8.0-apache",
-          "8.1-apache",
-          "8.2-apache",
-          "8.3-apache",
-          "8.4-apache",
-          "8.5-apache"
-        ]
+        # Full matrix on push to long-lived branches (main, develop) and version tags.
+        # PRs and feature-branch pushes run extremes-only (8.0 + 8.5) since
+        # version-specific regressions historically surface at the edges.
+        php_tag: ${{ fromJSON((github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/tags/v')))) && '["8.0-apache","8.1-apache","8.2-apache","8.3-apache","8.4-apache","8.5-apache"]' || '["8.0-apache","8.5-apache"]') }}
 
     env:
       DISABLE_XDEBUG: "1"

--- a/docs/contributing/agents/working-with-agents.md
+++ b/docs/contributing/agents/working-with-agents.md
@@ -204,8 +204,8 @@ See [Console Commands](../../core-features/console-commands.md) for full flags.
 - **Conventional commits with a scope**: `feat(admin): …`, `fix(layout): …`, `refactor(maintenance): …`, `test(...)`, `docs(...)`. See [How To Contribute](../how-to-contribute.md) for the migration from Gitmoji.
 - **Atomic commits.** Split work by scope. Example: a feature touching code + tests + docs becomes `refactor(...)`, `feat(...)`, `test(...)`, `docs(...)` — four commits, one scope each. Combining (`feat+test`) is not the project style.
 - **One-line messages, no `Co-Authored-By` trailer.**
-- **PR base is `main`.** Verify with `gh pr view <n> --json baseRefName` if unsure; some tooling surfaces stale branch names.
-- CI runs e2e on PHP 8.0, 8.1, 8.2, 8.3, 8.4, 8.5 in parallel. Watch with `gh pr checks <n> --repo zubzet/framework --watch`.
+- **PR base is `develop`.** Feature work merges into `develop`; `develop` is later promoted to `main` via a separate PR. Verify with `gh pr view <n> --json baseRefName` if unsure; some tooling surfaces stale branch names. See [How To Contribute → Branching model](../how-to-contribute.md#branching-model).
+- CI runs e2e on PHP 8.0 and 8.5 for PRs and feature-branch pushes (the version-edge smoke). Pushes to `develop`, `main`, and version tags run the full matrix (8.0–8.5). Watch with `gh pr checks <n> --repo zubzet/framework --watch`.
 
 ## Working style for AI agents
 

--- a/docs/contributing/how-to-contribute.md
+++ b/docs/contributing/how-to-contribute.md
@@ -2,6 +2,21 @@
 
 ## Git Workflow
 
+### Branching model
+
+The framework uses a two-tier integration flow:
+
+| Branch | Stability | Source of changes |
+| ------ | --------- | ----------------- |
+| `develop` | **Unstable.** Active integration branch. Features land here once reviewed. May contain in-progress combinations that haven't been validated together. | Feature-branch PRs |
+| `main` | **Release-candidate.** Mostly working, comparable to an RC. Only merged to from `develop` when the combined state is green and reviewed. | Promotion PRs from `develop` |
+
+Practical implications:
+
+- Feature work targets `develop`. PRs may be opened as **draft / WIP** while in progress.
+- Promotions to `main` happen as a separate PR (`develop` → `main`) when the maintainer is satisfied with the integrated state.
+- CI runs the full PHP matrix (8.0–8.5) on pushes to `develop`, `main`, and version tags. PRs and other branches run an extremes-only smoke (8.0 + 8.5).
+
 ### Setup
 
 - **Origin** (your fork): `git@github.com:your-username/framework.git`
@@ -9,12 +24,12 @@
 
 ### Common Workflows
 
-#### Update your local main branch from upstream
+#### Update your local develop branch from upstream
 
 ```bash
 git fetch upstream
-git checkout main
-git merge upstream/main
+git checkout develop
+git merge upstream/develop
 ```
 
 #### Create and push a feature branch
@@ -31,34 +46,46 @@ git push origin feature/your-feature-name
 
 1. Go to `https://github.com/zubzet/framework`
 2. Click "New Pull Request"
-3. Select `main` as base branch
+3. Select `develop` as base branch
 4. Select your feature branch as compare branch
-5. Create PR and request reviews
+5. Create PR and request reviews — open as draft while still in progress
 
 #### Sync your fork with upstream
 
-If main has changed while you're working on a feature branch:
+If develop has changed while you're working on a feature branch:
 
 ```bash
 git fetch upstream
-git rebase upstream/main
+git rebase upstream/develop
 git push origin feature/your-feature-name -f
 ```
 
-#### Keep your main branch in sync
+#### Keep your develop branch in sync
 
 ```bash
-git checkout main
+git checkout develop
 git fetch upstream
+git merge upstream/develop
+git push origin develop
+```
+
+#### Promote develop to main (maintainer)
+
+```bash
+git fetch upstream
+git checkout main
 git merge upstream/main
+git merge upstream/develop
 git push origin main
+# then open the PR upstream and let the full matrix run
 ```
 
 ### Important Notes
 
-- Always work on feature branches, never directly on main
-- Keep your fork updated frequently to avoid conflicts
-- Push to `origin` (your fork), create PR to `upstream` (main repo)
+- Always work on feature branches, never directly on `develop` or `main`.
+- Feature PRs target `develop`; only `develop` → `main` PRs target `main`.
+- Keep your fork updated frequently to avoid conflicts.
+- Push to `origin` (your fork), create PR to `upstream` (main repo).
 
 ## Commit Messages
 We previously used [gitmoji](https://gitmoji.dev/) for commits.


### PR DESCRIPTION
## Summary

Two coupled changes that together introduce a two-tier integration flow and cut PR CI cost.

### Branching model (docs only)

- **`develop`** — unstable, active integration branch. Feature-branch PRs target this. May be opened as draft / WIP.
- **`main`** — release-candidate, mostly working. Promoted from `develop` via a separate PR when the integrated state is reviewed and green.

Documented in:
- `docs/contributing/how-to-contribute.md` — branching-model table, updated workflow snippets, promote-to-main snippet
- `docs/contributing/agents/working-with-agents.md` — PR base updated to `develop`, CI matrix policy noted

### CI matrix policy

- **PRs and feature-branch pushes** → 8.0 + 8.5 only (extremes-only smoke). Version-specific regressions historically surface at the edges, not the middle.
- **Pushes to `main`, `develop`, version tags `v*.*.*`, and manual `workflow_dispatch`** → full matrix (8.0–8.5).

Implemented inline in the matrix definition with a `fromJSON` ternary so no extra job is needed.

### Outcome

- ✅ This PR ran with the new logic and only `e2e (8.0-apache)` + `e2e (8.5-apache)` were scheduled. Wall time unchanged (~6 min, jobs were already parallel) but compute use drops 3× per PR run.
- ✅ Post-merge push to `main` triggered the full 6-version matrix (run [25049396296](https://github.com/zubzet/framework/actions/runs/25049396296), all green).
- ✅ The `develop` branch was created on `zubzet/framework` from `main` after merge — feature PRs now target `develop`.