### PR TITLE
perf(cypress): inline cy.dbSeed to skip npm bootstrap

### DIFF
--- a/tests/e2e/tests/cypress/support/database.js
+++ b/tests/e2e/tests/cypress/support/database.js
@@ -1,4 +1,5 @@
 Cypress.Commands.add('dbSeed', () => {
-    cy.exec('npm run seed');
+    // Skip the npm-script bootstrap that `npm run seed` adds.
+    cy.exec('docker exec application php index.php db:seed');
     Cypress.session.clearAllSavedSessions();
 })


### PR DESCRIPTION
## Summary

`cy.dbSeed()` was running `npm run seed`, which spawns npm just to invoke `docker exec application php index.php db:seed` — adding the npm-script bootstrap to every call. ~40 specs call `cy.dbSeed()` in their `before()` hook.

Switching to a direct `cy.exec('docker exec ...')` removes the indirection.

## Measurement

**Local (5 runs each):**

| Approach | Avg duration |
| -------- | ------------ |
| `npm run seed` | 838 ms |
| `docker exec ... db:seed` | 745 ms |

× ~40 specs ≈ 3–4 s of theoretical saving per cypress run.

**CI (this PR vs prior baseline on `main`):**

| | Cypress avg across 6 PHP versions |
| --- | --- |
| Baseline | ~277 s |
| This PR | ~278 s |

The saving is within CI variance — not visibly faster on GitHub-hosted runners. Kept anyway: removes an unnecessary npm bootstrap from a path called 40+ times per run; the local measurement confirms a real (if small) saving on faster hosts.

## Outcome

- ✅ `permission/user.cy.js` (uses `cy.dbSeed`) — 23/23 pass locally
- ✅ CI on this PR — full matrix all green