### PR TITLE
perf(ci): use bun for dependency install

### DIFF
--- a/.github/workflows/tests_e2e.yml
+++ b/.github/workflows/tests_e2e.yml
@@ -61,12 +61,10 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
         with:
-          node-version: 20
-          cache: npm
-          cache-dependency-path: tests/e2e/package-lock.json
+          bun-version: latest
 
       - name: Cache Cypress binary
         uses: actions/cache@v4
@@ -76,8 +74,8 @@ jobs:
           restore-keys: |
             cypress-${{ runner.os }}-
 
-      - name: Install NPM dependencies
-        run: npm ci
+      - name: Install dependencies
+        run: bun install
 
       - name: Detect host UID
         run: echo "HOST_UID=$(id -u)" >> $GITHUB_ENV
@@ -122,7 +120,7 @@ jobs:
       - name: Run E2E tests (Cypress)
         env:
           CI: true
-        run: npm run tests
+        run: bun run tests
 
       - name: Upload Cypress videos
         if: failure()

--- a/tests/e2e/.gitignore
+++ b/tests/e2e/.gitignore
@@ -2,6 +2,10 @@ composer.lock
 logging
 z_config/z_cache.ini
 
+# Bun lockfile — CI migrates from package-lock.json on every run, so committing
+# bun.lock would create a second lockfile to keep in sync with no real benefit.
+bun.lock
+
 # Fixtures temporarily copied into the app during e2e runs (cleaned up by tests,
 # but listed here so an interrupted run never lets them slip into a commit).
 app/Database/migrations/Syntax.sql


### PR DESCRIPTION
## Summary

Replace `actions/setup-node@v4` + `npm ci` with `oven-sh/setup-bun@v2` + `bun install` in the e2e CI workflow. `npm run tests` becomes `bun run tests` for consistency.

Bun migrates from the existing `package-lock.json` automatically (~12 ms), so the source of truth stays `package-lock.json` — no second lockfile to maintain. `bun.lock` is added to `tests/e2e/.gitignore` to keep accidental commits out.

## Measurement

**Local:**

| Approach | Duration |
| -------- | -------- |
| `bun install` (clean cache) | 1.3 s |
| `bun install` (warm cache) | <100 ms |
| `npm ci` (clean cache, prior CI) | ~2–3 s |

**CI (this PR):**

- `Install dependencies`: 0–4 s across 6 jobs (mostly under 1 s, filtered as too short to display)
- `Set up Node.js` step removed entirely → another ~3–5 s saved per job

Net wall-clock saving per matrix entry: ~3–5 s. Modest, but the workflow is also slightly cleaner.

## Local dev

Unchanged. `package.json` still defines the same scripts; `npm run start` / `npm run tests` continue to work for devs who haven't installed bun.

## Outcome

- ✅ `bun install` + `bun run tests -- --spec permission/user.cy.js` — 23/23 pass locally
- ✅ CI on this PR — full matrix all green