### PR TITLE
fix(e2e): override uuid to ^14.0.0

### DIFF
--- a/tests/e2e/package-lock.json
+++ b/tests/e2e/package-lock.json
@@ -2148,13 +2148,17 @@
             }
         },
         "node_modules/uuid": {
-            "version": "8.3.2",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+            "version": "14.0.0",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+            "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
             "dev": true,
+            "funding": [
+                "https://github.com/sponsors/broofa",
+                "https://github.com/sponsors/ctavan"
+            ],
             "license": "MIT",
             "bin": {
-                "uuid": "dist/bin/uuid"
+                "uuid": "dist-node/bin/uuid"
             }
         },
         "node_modules/verror": {

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -20,5 +20,8 @@
         "chai": "^6.2.2",
         "cypress": "^15.14.0",
         "unicode-substring": "^1.0.0"
+    },
+    "overrides": {
+        "uuid": "^14.0.0"
     }
 }


### PR DESCRIPTION
## Summary

Resolves Dependabot alert [#27](https://github.com/zubzet/framework/security/dependabot/27): _uuid: Missing buffer bounds check in v3/v5/v6 when buf is provided_ (vulnerable range \`< 14.0.0\`).

\`uuid@8.3.2\` is pulled in transitively by \`cypress@15.14.0 → @cypress/request@3.0.10\`. We don't control that path; cypress hasn't bumped it yet. Adding an \`npm overrides\` entry forces \`uuid@^14.0.0\` for the whole \`tests/e2e\` tree.

## Scope

Test-only project (\`tests/e2e/\`). No framework code, no \`composer.json\` change, no PHP affected.

## Verification

- \`npm install\` resolves to \`uuid@14.0.0\` under \`@cypress/request@3.0.10\`
- \`npm audit\` reports \`found 0 vulnerabilities\`
- \`cypress run --spec permission/user.cy.js\` — 23/23 pass locally with the overridden version