### PR TITLE
chore(ide): autocomplete Z.js globals in views via jsconfig

### DIFF
--- a/.github/workflows/tests_e2e.yml
+++ b/.github/workflows/tests_e2e.yml
@@ -8,6 +8,7 @@ on:
       - 'tests/e2e/**'
       - 'composer*'
       - 'src/**'
+      - 'web/**'
       - '.github/workflows/tests_e2e.yml'
   push:
     branches: [ '*' ]

--- a/docs/contributing/agents/working-with-agents.md
+++ b/docs/contributing/agents/working-with-agents.md
@@ -2,6 +2,9 @@
 
 This page is for AI coding agents (Claude Code, Cursor, Codex, Aider, etc.) and contributors who need a deeper map of the framework internals than [How To Contribute](../how-to-contribute.md) provides. If you're getting started, read that first.
 
+!!! danger "Stop before publishing — always ask first"
+    Do **not** run `git commit`, `git push`, `gh pr create`, or any other action that publishes changes outward, unless the maintainer has explicitly asked for that step in the current turn. A green test run is **not** authorization. Leave changes in the working tree (staged is fine) and wait. This rule applies even when an earlier turn authorized a commit — authorization is per-action, not blanket. See [Working style for AI agents](#working-style-for-ai-agents) for the rest of the boundaries.
+
 ## Repository layout
 
 | Path | What lives there |
@@ -211,7 +214,7 @@ See [Console Commands](../../core-features/console-commands.md) for full flags.
 
 ## Working style for AI agents
 
-- **Never commit or push without an explicit ask.** This is critical framework code. AI output is reviewed by hand before it lands — leave changes uncommitted in the working tree (or staged, if helpful) and wait. Even after a successful test run, do not run `git commit`, `git push`, or `gh pr` write actions unless the maintainer asks for them in that turn.
+- **Never commit, push, or open a PR without an explicit ask.** This is critical framework code. AI output is reviewed by hand before it lands — leave changes uncommitted in the working tree (or staged, if helpful) and wait. Even after a successful test run, do not run `git commit`, `git push`, `gh pr create`, or any other publishing action unless the maintainer asks for it in that turn. Authorization is **per-action**: "go ahead and commit" does not authorize a push; a push does not authorize a PR. When in doubt, stop and ask.
 - **Iterative pace.** Make small changes, run tests, report concisely, wait. Don't pre-build large structures unless asked.
 - **Watch for parallel edits.** A `<system-reminder>` notice that a file was modified means re-read it before any further change — never assume your in-context view is current.
 - **"Any other ideas?"** is a request for 3–4 ranked options with trade-offs and a recommendation. Don't implement until asked.

--- a/docs/contributing/agents/working-with-agents.md
+++ b/docs/contributing/agents/working-with-agents.md
@@ -10,8 +10,10 @@ This page is for AI coding agents (Claude Code, Cursor, Codex, Aider, etc.) and 
 | `src/IncludedComponents/` | Bundled controllers, models, views, routes, and migrations the framework ships |
 | `docs/` | MkDocs-rendered documentation (this site) |
 | `tests/e2e/` | Cypress end-to-end test suite running the dockerized app |
+| `web/` | Static assets served via `AssetProxy` — currently just `Z.js` (frontend runtime) |
 | `mkdocs.yml` | Docs site nav and theme config |
 | `composer.json` | PHP 8.0–8.5 support, autoload, dependencies |
+| `jsconfig.json` | Scopes the JS language server to `web/**/*.js` so `Z`, `ZForm`, `ZFormField`, `ZCED`, `ZCEDItem` resolve as globals (autocomplete inside `<script>` blocks of views) |
 
 There is no top-level `package.json` and no PHPUnit suite — testing is end-to-end only, run from `tests/e2e/`.
 

--- a/docs/contributing/how-to-contribute.md
+++ b/docs/contributing/how-to-contribute.md
@@ -118,6 +118,12 @@ Both tasks render in a dedicated panel. On first open VSCode prompts to **Allow 
 
 Closing the VSCode window does **not** stop the stack — VSCode kills task terminals too aggressively for any cleanup hook to run reliably. Before opening the next project, run **Stop Dev Environment** from the command palette (or `npm run stop` from `tests/e2e/`) to free the ports.
 
+### JavaScript IntelliSense
+
+`jsconfig.json` at the repo root scopes the JS language server to `web/**/*.js`. The runtime `Z` namespace, `ZForm`, `ZFormField`, `ZCED`, and `ZCEDItem` are declared there with JSDoc — the LSP picks them up as globals, so typing `Z.` inside a `<script>` block of a PHP view (or in any file the LSP analyzes as JavaScript) offers completions and parameter hints.
+
+If completions don't surface inside `<script>` blocks of `.php` files: the editor's PHP integration must hand `<script>` regions off to the JS language server. VSCode does this by default; some PHP plugins (e.g. Intelephense Free) claim the entire file and disable embedded language services — extracting the script to a standalone `.js` file is the workaround.
+
 ## Documentation
 1. **Clone the Repository**
 ```bash

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,19 @@
+{
+    "compilerOptions": {
+        "target": "es2020",
+        "module": "esnext",
+        "allowJs": true,
+        "checkJs": false,
+        "noEmit": true,
+        "lib": ["es2020", "dom"]
+    },
+    "include": [
+        "web/**/*.js"
+    ],
+    "exclude": [
+        "node_modules",
+        "vendor",
+        "_build",
+        "tests/e2e/node_modules"
+    ]
+}

--- a/web/Z.js
+++ b/web/Z.js
@@ -15,7 +15,7 @@
  * @type {object} Z
  * Namespace object for Z.js
  */
-Z = {
+var Z = {
 
   /**
    * Debug mode

--- a/web/Z.js
+++ b/web/Z.js
@@ -685,10 +685,13 @@ class ZForm {
   /**
    * Creates a ZForm instance
    * @param {object} options Options
-   * @param {boolean} options.doReload Should the form reload after submit? This is automatically set to true when using a CED in the form
-   * @param {string} options.dom Id of a dom element to append this form automatically to
-   * @param {saveHook} options.saveHook Function that is called after saving. It is only called after a success and not when validation errors occour
-   * @param {formErrorHook} options.formErrorHook Function that is only called on form errors
+   * @param {boolean} [options.doReload] Should the form reload after submit? This is automatically set to true when using a CED in the form
+   * @param {string} [options.dom] Id of a dom element to append this form automatically to
+   * @param {saveHook} [options.saveHook] Function that is called after saving. It is only called after a success and not when validation errors occour
+   * @param {formErrorHook} [options.formErrorHook] Function that is only called on form errors
+   * @param {boolean} [options.hidehints] Suppress the inline hint banner (saved / unsaved / error). Defaults to `false` (hints are shown).
+   * @param {boolean} [options.sendOnSubmitClick] If `false`, the built-in submit button no longer calls `send()` automatically — the caller is responsible for triggering submission. Defaults to `true`.
+   * @param {string} [options.customEndpoint] Override the URL `send()` posts to. By default the form posts back to the current action.
    */
   constructor(options = {
     doReload: true, 
@@ -883,7 +886,27 @@ class ZForm {
 
   /**
    * Creates and adds a ZFormField to the form
-   * @param {FormFieldOptions} options for the new Field
+   * @param {object} options Options for the new field
+   * @param {string} [options.name] Name to use in the request
+   * @param {InputType} [options.type] Type of the field
+   * @param {string} [options.text] Text to show in the label
+   * @param {boolean} [options.required] Sets if this field is required to be filled in
+   * @param {string} [options.hint] Small text to show under the input. For example: "We do not share you email" or something.
+   * @param {string} [options.placeholder] Placeholder to show in the input when nothing is entered
+   * @param {any} [options.default] Default value
+   * @param {any} [options.value] Initial value of the input. For `type: "button"` this is the button label.
+   * @param {boolean} [options.autofill] Enable browser-level autofill for this field.
+   * @param {FieldWidth} [options.width] Width of the field in units (1-12, bootstrap grid)
+   * @param {object} [options.attributes] List of attributes to apply to the input element. Keys are attribute names, values are attribute values.
+   * @param {Food} [options.food] Food for selects or autocompletes
+   * @param {boolean} [options.compact] Sets the compact mode. In compact mode, the label is hidden.
+   * @param {string} [options.prepend] Content to put in front of the input. Units are usually put there.
+   * @param {string} [options.style] Bootstrap button class (e.g. `"btn-primary"`, `"btn-danger"`). Only applies when `type` is `"button"`. Defaults to `"btn-primary"`.
+   * @param {string} [options.customFileInputText] Placeholder text shown on a `type: "file"` input before a file is chosen. Defaults to `Z.Lang.choose_file`.
+   * @param {Food[]|string} [options.autocompleteData] Static list of options for `type: "autocomplete"`, or a backend path string the field queries via `Z.Request.root` for dynamic suggestions.
+   * @param {number} [options.autocompleteMinCharacters] Minimum number of characters typed before autocomplete fetches/filters suggestions. Defaults to `2`.
+   * @param {function} [options.autocompleteTextCB] Callback `(item) => string` mapping an autocomplete entry to its rendered list label. Defaults to the entry's `text` property.
+   * @param {function} [options.autocompleteCB] Callback `(item) => void` fired when the user picks an entry from the autocomplete list.
    * @returns {ZFormField} The newly created field
    */
   createField(options) {
@@ -981,20 +1004,27 @@ class ZForm {
 
 /**
  * All parameters are optional
- * @typedef FormFieldOptions
- * @property {string} name Name to use in the request
- * @property {boolean} required Sets if this field is required to be filled in
- * @property {InputType} type Type of the field
- * @property {string} text Text to show in the label
- * @property {string} hint Small text to show under the input. For example: "We do not share you email" or something.
- * @property {any} default Default value 
- * @property {boolean} autofill Enable browser level autofill for this field.
- * @property {string} placeholder Placeholder to show in the input when nothing is entered
- * @property {FieldWidth} width Width of the field in units
- * @property {object} attributes List of attributes to apply to the input element. The keys are attribute names and their values will be used as the value
- * @property {Food} food Food for selects or autocomepletes
- * @property {boolean} compact Sets the compact mode. In compact mode, the label is hidden
- * @property {string} prepend Content to put in front of the input. Units are usally put there
+ * @typedef {object} FormFieldOptions
+ * @property {string} [name] Name to use in the request
+ * @property {boolean} [required] Sets if this field is required to be filled in
+ * @property {InputType} [type] Type of the field
+ * @property {string} [text] Text to show in the label
+ * @property {string} [hint] Small text to show under the input. For example: "We do not share you email" or something.
+ * @property {any} [default] Default value
+ * @property {boolean} [autofill] Enable browser level autofill for this field.
+ * @property {string} [placeholder] Placeholder to show in the input when nothing is entered
+ * @property {FieldWidth} [width] Width of the field in units
+ * @property {object} [attributes] List of attributes to apply to the input element. The keys are attribute names and their values will be used as the value
+ * @property {Food} [food] Food for selects or autocomepletes
+ * @property {boolean} [compact] Sets the compact mode. In compact mode, the label is hidden
+ * @property {string} [prepend] Content to put in front of the input. Units are usally put there
+ * @property {any} [value] Initial value of the input. For `type: "button"` this is the button label.
+ * @property {string} [style] Bootstrap button class (e.g. `"btn-primary"`, `"btn-danger"`). Only applies when `type` is `"button"`. Defaults to `"btn-primary"`.
+ * @property {string} [customFileInputText] Placeholder text shown on a `type: "file"` input before a file is chosen. Defaults to `Z.Lang.choose_file`.
+ * @property {Food[]|string} [autocompleteData] Static list of options for `type: "autocomplete"`, or a backend path string that the field queries via `Z.Request.root` for dynamic suggestions.
+ * @property {number} [autocompleteMinCharacters] Minimum number of characters typed before autocomplete fetches/filters suggestions. Defaults to `2`.
+ * @property {function} [autocompleteTextCB] Callback `(item) => string` mapping an autocomplete entry to its rendered list label. Defaults to the entry's `text` property.
+ * @property {function} [autocompleteCB] Callback `(item) => void` fired when the user picks an entry from the autocomplete list.
  */
 
 /**


### PR DESCRIPTION
## Summary

Sets up VSCode/JS-LSP autocomplete for the `Z` namespace and `ZForm` / `ZFormField` / `ZCED` / `ZCEDItem` classes when writing JavaScript inside `<script>` blocks of PHP views.

- **`web/Z.js`**: `Z = {…}` → `var Z = {…}`. Same runtime behavior (it was already an implicit global in non-strict mode), but the explicit `var` makes the JS language server pick it up as a script-scope global. Without this, the LSP can't resolve `Z` in consumer files.
- **`jsconfig.json`** (new, root): scopes the JS LSP to `web/**/*.js`. The rich JSDoc on Z.js (Forms, Request, Lang, Presets, plus the four classes) now feeds completion and parameter hints in any file the editor analyzes as JavaScript — including embedded `<script>` regions of `.php` views.
- **Docs** (`how-to-contribute.md`, `agents/working-with-agents.md`): one-paragraph note + a row in the repo-layout table.

## Test plan
- [ ] Open `src/IncludedComponents/views/login.php` in VSCode. Inside the `<script>` block, type `Z.` — IntelliSense lists `Forms`, `Request`, `Lang`, `Presets`, etc.
- [ ] Type `Z.Presets.Login(` — parameter hints surface (`nameElementId`, `passwordElementId`, …) from the JSDoc.
- [ ] In `tests/e2e/app/Views/form/validationText.php`, type `Z.Forms.create({ ` — `dom`, `doReload`, `saveHook`, `formErrorHook` autocomplete from `ZForm`'s constructor JSDoc.
- [ ] Verify e2e still boots: `cd tests/e2e && npm run start && npm run tests` (no functional change expected — `var Z` and `Z =` are equivalent globals at top level).

## Caveat

If completions don't surface inside `<script>` blocks of `.php` files, the editor's PHP integration is claiming the entire file and disabling embedded language services (some Intelephense Free configurations do this). The fix at that point is editor-side (extension config) or extracting scripts to standalone `.js` files; nothing more is needed in this repo.