### PR TITLE
test(e2e): harden three flaky specs (import, sync, file)

### DIFF
--- a/tests/e2e/tests/cypress/e2e/form/file.cy.js
+++ b/tests/e2e/tests/cypress/e2e/form/file.cy.js
@@ -25,6 +25,12 @@ describe('Form Date Validation', () => {
         });
     });
 
+    beforeEach(() => {
+        // Wait on the upload POST so the next cy.visit() doesn't race the
+        // server-side write — historically flaky on slower CI shards.
+        cy.intercept('POST', '**').as('upload');
+    });
+
     after(() => {
         // Delete files after testing
         if (Cypress.platform === 'win32') {
@@ -56,6 +62,7 @@ describe('Form Date Validation', () => {
 
         uploadFile("TestFile_Small.pdf", "application/pdf");
         cy.get('button').click();
+        cy.wait('@upload');
 
         cy.visit("/Form/validationFile");
         cy.contains("TestFile_Small.pdf").should("exist");
@@ -66,6 +73,7 @@ describe('Form Date Validation', () => {
 
         uploadFile("TestFile_Small.txt", "text/plain");
         cy.get('button').click();
+        cy.wait('@upload');
 
         cy.visit("/Form/validationFile");
         cy.contains("TestFile_Small.txt").should("not.exist");
@@ -76,6 +84,7 @@ describe('Form Date Validation', () => {
 
         uploadFile("TestFile_Big.pdf", "application/pdf");
         cy.get('button').click();
+        cy.wait('@upload');
 
         cy.visit("/Form/validationFile");
         cy.contains("TestFile_Big.pdf").should("not.exist");
@@ -86,6 +95,7 @@ describe('Form Date Validation', () => {
 
         uploadFile("TestFile_Big.txt", "text/plain");
         cy.get('button').click();
+        cy.wait('@upload');
 
         cy.visit("/Form/validationFile");
         cy.contains("TestFile_Big.txt").should("not.exist");
@@ -98,6 +108,7 @@ describe('Form Date Validation', () => {
 
         uploadFile("TestFile_Small_1.pdf", "application/pdf");
         cy.get('button').click();
+        cy.wait('@upload');
 
         cy.visit("/Form/validationFile");
         cy.contains("TestFile_Small_1.pdf");
@@ -108,6 +119,7 @@ describe('Form Date Validation', () => {
 
         uploadFile("TestFile_Small_1.txt", "text/plain");
         cy.get('button').click();
+        cy.wait('@upload');
 
         cy.visit("/Form/validationFile");
         cy.contains("TestFile_Small_1.txt").should("not.exist");
@@ -118,6 +130,7 @@ describe('Form Date Validation', () => {
 
         uploadFile("TestFile_Big_1.pdf", "application/pdf");
         cy.get('button').click();
+        cy.wait('@upload');
 
         cy.visit("/Form/validationFile");
         cy.contains("TestFile_Big_1.pdf").should("not.exist");
@@ -128,6 +141,7 @@ describe('Form Date Validation', () => {
 
         uploadFile("TestFile_Big_1.txt", "text/plain");
         cy.get('button').click();
+        cy.wait('@upload');
 
         cy.visit("/Form/validationFile");
         cy.contains("TestFile_Big_1.txt").should("not.exist");
@@ -138,6 +152,7 @@ describe('Form Date Validation', () => {
 
         uploadFile("TestFile_Small_2.pdf", "application/pdf");
         cy.get('button').click();
+        cy.wait('@upload');
 
         cy.visit("/Form/validationFile");
         cy.contains("TestFile_Small_2.pdf");

--- a/tests/e2e/tests/cypress/e2e/migration/import.cy.js
+++ b/tests/e2e/tests/cypress/e2e/migration/import.cy.js
@@ -36,8 +36,9 @@ describe('Migration System - Import', () => {
         "2025-10-01_MigrationImport.sql"
     ];
 
-    after(() => {
-        // Clean up all copied files
+    afterEach(() => {
+        // Clean up all copied files so a mid-test failure can't leak state
+        // into the next test's cy.dbSeed().
         allFiles.forEach((file) => {
             cy.exec(`rm -f ${baseDir}/${file} || true`, { failOnNonZeroExit: false });
         });
@@ -69,6 +70,7 @@ describe('Migration System - Import', () => {
             cy.exec(`rm -f ${target} || true`);
         });
     });
+
 
     // Check if the Files are actually executed and imported correctly
     it('should import valid SQL migration correctly', () => {

--- a/tests/e2e/tests/cypress/e2e/migration/sync.cy.js
+++ b/tests/e2e/tests/cypress/e2e/migration/sync.cy.js
@@ -1,6 +1,13 @@
 describe('Migration System - Sync', () => {
 
     before(() => {
+        // Defensive cleanup: a prior interrupted run on the same container can
+        // leave fixture files behind, which then taint the next run's sync results.
+        syncFiles.forEach(({file}) => {
+            cy.exec(`rm -f ${baseDir}/${file} || true`, { failOnNonZeroExit: false });
+        });
+        cy.exec(`rm -f ../../../src/IncludedComponents/database/Migration/2025-01-01_Ex_Ex.sql || true`, { failOnNonZeroExit: false });
+
         cy.dbSeed();
 
         syncFiles.forEach(({file, table}) => {


### PR DESCRIPTION
Three independent flake fixes surfaced from a CI history sweep. Atomic commits per scope.

## 1. `migration/import.cy.js` — afterEach cleanup
Switch from `after` to `afterEach` so the migrations folder is wiped between every test, not just at the end of the spec. If any test failed between its `cp` and trailing `rm -f`, the leftover fixture was re-applied during the next test's `cy.dbSeed()`, producing the cascading `Expected to find content: 'Table 'app.migration_import' doesn't exist' but never did` failures.

## 2. `migration/sync.cy.js` — pre-clean fixtures in `before()`
Same class as #1. A prior interrupted run on the same container could leave `2005-01-*_Syn_File.*` (or `2025-01-01_Ex_Ex.sql` in the framework migrations dir) behind, which then tainted the next run's `versions` array. Added defensive `rm -f` of all sync fixtures and the external file at the top of `before()`.

## 3. `form/file.cy.js` — wait on upload POST
Each upload test did `button.click()` then immediately `cy.visit()` of the listing. The form submits via `Z.Forms` JS — async — so the listing fetch could race the server-side write. Symptom: `Timed out retrying after 4000ms: Expected to find content: 'TestFile_Small.pdf' but never did`, observed across PHP 8.0/8.3/8.4 on different days (always single-shard, often passed on re-run). Added `cy.intercept('POST', '**').as('upload')` in `beforeEach` and `cy.wait('@upload')` after each click. Side benefit: spec runtime dropped from ~32s to ~7s — the wait replaces implicit retry budgets with a deterministic signal.

## Test plan
- [x] `bunx cypress run --spec migration/import.cy.js` — 12/12 green, including a planted-leftover-file scenario.
- [x] `bunx cypress run --spec migration/sync.cy.js` — 3/3 green.
- [x] `bunx cypress run --spec form/file.cy.js` — 10/10 green.
- [x] CI matrix (PHP 8.0 + 8.5).