### PR TITLE
feat(forms): add multi-select field type and array-aware validation rules

### DIFF
--- a/docs/forms/auto-form-validation.md
+++ b/docs/forms/auto-form-validation.md
@@ -28,10 +28,10 @@ The form is created with `Z.Forms.create`. The `dom` attribute takes the id of a
 | Attribute   | Description                                                                                                                                                                                                                                                                                                    |
 |-------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `name`      | Corresponds to the name in the post request.                                                                                                                                                                                                                                                                   |
-| `type`      | The input type. Any valid HTML standard type is accepted, as well as `textarea` and `select`. This attribute does not affect server-side value parsing.                                                                                                                                                         |
+| `type`      | The input type. Any valid HTML standard type is accepted, as well as `textarea`, `select`, `multi-select`, and `autocomplete`. This attribute does not affect server-side value parsing.                                                                                                                       |
 | `text`      | Label text for the input field.                                                                                                                                                                                                                                                                               |
-| `value`     | Default value for the input field.                                                                                                                                                                                                                                                                            |
-| `food`      | Required for `select` types. It defines the options available and is formatted as an array: `[{value: 1, text: "one"}, {value: 2, text: "two"}, ...]`. This array can be generated via `$controller->makeFood`.                                                                                                  |
+| `value`     | Default value for the input field. For `multi-select`, pass an array (e.g. `["1","4"]`) or `<?= json_encode([...]) ?>`.                                                                                                                                                                                       |
+| `food`      | Required for `select` and `multi-select` types. It defines the options available and is formatted as an array: `[{value: 1, text: "one"}, {value: 2, text: "two"}, ...]`. This array can be generated via `$controller->makeFood`.                                                                              |
 | `required`  | Specifies whether the field is required. When set to `true`, the input must be filled before form submission.                                                                                                                                                                                                  |
 | `width`     | Defines the width of the form element in 1/12 units of the total width. Effective on medium or larger devices. On small devices, the width is always 100%.                                                                                                                                                      |
 | `attributes`| Allows adding additional attributes for the generated input element (e.g., `min`, `max` for number inputs). Example usage: `attributes: {'min': 1, 'max': 10}`.                                                                                                                                                  |
@@ -89,6 +89,23 @@ As the first parameter it takes an array of fields to validate. To these field, 
 `$formResult->hasErrors` returns true or false depended on the validation result of `$req->validateForm()`.
 If the validation fails, `$res->formErrors($formResult->errors)` will return the errors to the frontend, where they will be displayed.
 
+### **Rules on array values (multi-select)**
+
+A `multi-select` field's value arrives at the server as a real PHP array. Three existing rules are *list-aware* — they adapt automatically when the field value is an array — and one new rule (`->in()`) covers the in-memory allow-list case:
+
+- `->length($min, $max)` — `strlen()` for scalars; **`count()`** for arrays. So `->length(1, 3)` on a multi-select means "between 1 and 3 selections."
+- `->regex($pattern, $exceptions)` — runs the regex against each item; the field fails as soon as any item fails.
+- `->exists("table", "field")` — applied per item: every picked entry must exist as a row's `field` in `table`.
+- `->in($allowedValues)` — the value (or each item, for arrays) must appear in the given in-memory allow-list. No DB query. Use this to guard `select` / `multi-select` fields against tampered POST payloads where the client sent an option that wasn't in the rendered dropdown. Works on plain `select` (single-value) and `multi-select` (per-item).
+
+```php
+$formResult = $req->validateForm([
+    (new FormField("skills"))
+        ->required()
+        ->length(1, 5)
+        ->in($availableSkillIds),   // every picked id must be in the rendered list
+]);
+```
 
 ### **Saving functions**
 
@@ -232,6 +249,7 @@ public function action_manage(Request $req, Response $res) {
 - Additionally supported::
     - textarea
     - select
+    - multi-select
     - autocomplete
 
 ### Autocomplete
@@ -350,3 +368,74 @@ return $res->render("employee/employee_edit.php", [
     });
 </script>
 ```
+
+### Multi Select
+The `multi-select` type behaves like `select` but lets the user pick more than one value. Picked entries appear as removable badges under the dropdown and the picked option is hidden from the dropdown until the badge is removed. Uses the same `food` shape (and same `makeFood` helper) as `select`.
+
+#### Value semantics
+- `field.value` returns the picked entries as a **JavaScript array** of values.
+- Assigning `field.value = ["a", "b"]` replaces the selection. Non-array input is treated as an empty selection.
+- On submit, each pick is sent as a native PHP array entry (`name[]=a&name[]=b`), so `$_POST[name]` arrives as a real **PHP array** — no `json_decode` needed in user code. An **empty** multi-select is omitted from the POST entirely — just like an unchecked checkbox — so the existing `->required()` rule (`isset($_POST[$name])`) catches it without any special-casing.
+- `insertDatabase` / `updateDatabase` automatically `json_encode` array field values before binding, so a `JSON` (or `TEXT`/`VARCHAR`) column receives a real JSON string. User code never has to encode manually.
+- Pre-fill from PHP with either an inline JS literal or `json_encode` dumped directly (no surrounding quotes):
+
+```php
+form.createField({
+    name: "skills",
+    type: "multi-select",
+    food: <?= $opt["skillsFood"] ?>,
+    value: <?= json_encode($opt["employee"]["skills"] ?? []) ?>,
+});
+```
+
+#### Food shapes
+- `{value, text}` — value is what gets posted, text is what's shown in the dropdown and the badge.
+- `{value}` alone — value is also used as the label.
+- `{text}` alone — text doubles as the value.
+- `{type: "optgroup", text}` — groups the options that follow (until the next optgroup) under an `<optgroup>` label. Optgroups are collapsed automatically when every option below them has been picked, and come back when one is removed.
+
+#### Example
+
+```php
+// Controller
+return $res->render("project/manage.php", [
+    "skills" => $this->makeFood(
+        $req->getModel("Skill")->getAll(),
+        "id", "name",
+    ),
+]);
+```
+
+```js
+// View
+<div id="form"></div>
+<script>
+    var form = Z.Forms.create({ dom: "form" });
+
+    form.createField({
+        name: "skills",
+        type: "multi-select",
+        text: "Skills",
+        placeholder: "Add a skill...",   // replaces the default "---"
+        food: <?= $opt["skills"] ?>,
+        required: true,                  // empty selection fails ->required()
+        default: ["1"],                  // pre-fill; reset() returns to this
+    });
+</script>
+```
+
+#### Backend
+```php
+$formResult = $req->validateForm([
+    (new FormField("skills", "skills_json"))
+        ->required(),
+]);
+
+if ($formResult->hasErrors) {
+    return $res->formErrors($formResult->errors);
+}
+
+$res->insertDatabase("project", $formResult);
+```
+
+`$req->getPost("skills")` and `$formResult->fields[0]->value` both come back as real PHP arrays (e.g. `["1", "4"]`). `insertDatabase` then auto-`json_encode`s the array before binding, so the column stores a JSON string (`["1","4"]`) — a `JSON`, `TEXT`, or `VARCHAR` column all work. Nothing in user code needs to special-case the multi-select.

--- a/src/Form/Validation/CanValidateForm.php
+++ b/src/Form/Validation/CanValidateForm.php
@@ -76,6 +76,16 @@
                                     break;
                                 }
                             }
+                        } else if ($type == "in") {
+                            // Array values: every item must be in the
+                            // configured in-memory allow-list.
+                            $items = is_array($value) ? $value : [$value];
+                            foreach ($items as $item) {
+                                if (!in_array($item, $rule["allowedValues"])) {
+                                    $errors[] = ["name" => $name, "type" => "in"];
+                                    break;
+                                }
+                            }
                         } else if ($type == "regex") {
                             // For array values the regex is applied per item;
                             // the field fails as soon as any item fails.

--- a/src/Form/Validation/CanValidateForm.php
+++ b/src/Form/Validation/CanValidateForm.php
@@ -46,7 +46,9 @@
                         $value = $data[$name];
 
                         if ($type == "length") {
-                            $len = strlen($value);
+                            // For array values (e.g. multi-select) length is
+                            // the item count; for scalar values it's strlen.
+                            $len = is_array($value) ? count($value) : strlen($value);
                             if ($len < $rule["min"] || $len > $rule["max"]) {
                                 $errors[] = ["name" => $name, "type" => "length", "info" => [$rule["min"], $rule["max"]]];
                             }
@@ -65,16 +67,28 @@
                                 }
                             }
                         } else if ($type == "exist") {
-                            if (!db()->checkIfExists($rule["table"], $rule["field"], $value)) {
-                                $errors[] = ["name" => $name, "type" => "exist"];
+                            // Array values: every item must exist in the
+                            // configured (table, field).
+                            $items = is_array($value) ? $value : [$value];
+                            foreach ($items as $item) {
+                                if (!db()->checkIfExists($rule["table"], $rule["field"], $item)) {
+                                    $errors[] = ["name" => $name, "type" => "exist"];
+                                    break;
+                                }
                             }
                         } else if ($type == "regex") {
-                            $tmp_value = $value;
-                            foreach ($rule["exceptions"] as $exception) {
-                                $tmp_value = str_replace($exception, "", $tmp_value);
-                            }
-                            if (!preg_replace($rule["expression"], "", $tmp_value) != $tmp_value) {
-                                $errors[] = ["name" => $name, "type" => "regex"];
+                            // For array values the regex is applied per item;
+                            // the field fails as soon as any item fails.
+                            $items = is_array($value) ? $value : [$value];
+                            foreach ($items as $item) {
+                                $tmp_value = $item;
+                                foreach ($rule["exceptions"] as $exception) {
+                                    $tmp_value = str_replace($exception, "", $tmp_value);
+                                }
+                                if (!preg_replace($rule["expression"], "", $tmp_value) != $tmp_value) {
+                                    $errors[] = ["name" => $name, "type" => "regex"];
+                                    break;
+                                }
                             }
                         } else if ($type == "integer") {
                             if (filter_var($value, FILTER_VALIDATE_INT) === false) {

--- a/src/Form/Validation/Field.php
+++ b/src/Form/Validation/Field.php
@@ -131,6 +131,28 @@
         }
 
         /**
+         * Adds an `in` rule
+         *
+         * The submitted value must appear in the given in-memory allow-list.
+         * Unlike `exists()` this does not hit the database. Useful to guard
+         * `select` / `multi-select` fields against tampered POST payloads
+         * where the client sent an option that wasn't in the rendered
+         * dropdown. For array-valued fields the rule is applied per item:
+         * every picked entry must be in the allow-list.
+         *
+         * @param array $allowedValues The list of allowed values
+         * @return Field Returns itself to allow chaining
+         */
+        function in(array $allowedValues) {
+            $this->rules[] = [
+                "name" => $this->name,
+                "type" => "in",
+                "allowedValues" => $allowedValues,
+            ];
+            return $this;
+        }
+
+        /**
          * Adds a required rule
          * 
          * With this rule an error is created when no input for this field is given.

--- a/src/Form/Validation/Field.php
+++ b/src/Form/Validation/Field.php
@@ -64,9 +64,12 @@
 
         /**
          * Adds a filter rule
-         * 
+         *
          * Creates an error when a filter fails. All filter_var compatible filters are available.
-         * 
+         *
+         * Does not support array values (e.g. `multi-select`) — `filter_var()`
+         * expects a scalar; pair `multi-select` with `->in()` instead.
+         *
          * @param int $filter A valid PHP filter
          * @return Field Returns itself to allow chaining
          */
@@ -81,10 +84,13 @@
 
         /**
          * Adds a unique rule
-         * 
-         * This rule checks if a dataset with a specific value already exists.  
+         *
+         * This rule checks if a dataset with a specific value already exists.
          * A set to ignore can also be specified. An error will be created when the set exists.
-         * 
+         *
+         * Does not support array values (e.g. `multi-select`) — the rule
+         * runs a single uniqueness query against a scalar value.
+         *
          * @param string $table Table name in the database
          * @param string $field Field name in the table
          * @param string $ignoreField name of the field in which the ignore value is
@@ -105,19 +111,20 @@
 
         /**
          * Adds an exists rule
-         * 
-         * This rule checks if a dataset with a specific value already exists.  
-         * A set to ignore can also be specified. An error will be created when the set does not exist.
-         * 
+         *
+         * This rule checks if a dataset with a specific value already exists
+         * in the database. For array-valued fields (e.g. `multi-select`) the
+         * rule is applied per item, every picked entry must exist.
+         *
          * @param string $table Table name in the database
          * @param string $field Field name in the table
          * @return Field Returns itself to allow chaining
          */
         function exists($table, $field) {
             $this->rules[] = [
-                "name" => $this->name, 
-                "type" => "exist", 
-                "table" => $table, 
+                "name" => $this->name,
+                "type" => "exist",
+                "table" => $table,
                 "field" => $field
             ];
             return $this;
@@ -141,11 +148,15 @@
 
         /**
          * Adds a length rule
-         * 
-         * This rule will create an error when the input is too long or too short
-         * 
-         * @param int $min Minimum number of chars
-         * @param int $max Maximum number of chars
+         *
+         * This rule will create an error when the input is too long or too short.
+         *
+         * For array-valued fields (e.g. `multi-select`) length is measured as
+         * the item count (`count($value)`) instead of the character count, so
+         * `->length(1, 3)` means "between 1 and 3 selections."
+         *
+         * @param int $min Minimum number of chars (or items for arrays)
+         * @param int $max Maximum number of chars (or items for arrays)
          * @return Field Returns itself to allow chaining
          */
         function length($min, $max) {
@@ -160,10 +171,13 @@
 
         /**
          * Adds an integer rule
-         * 
+         *
          * This rule will create an error when the input was not a value that could be parsed to an integer.
          * Also this function sets the type of the field to "i".
-         * 
+         *
+         * Does not support array values (e.g. `multi-select`) — `filter_var()`
+         * and `intval()` expect a scalar.
+         *
          * @return Field Returns itself to allow chaining
          */
         function integer() {
@@ -177,9 +191,12 @@
 
         /**
          * Adds a range rule
-         * 
+         *
          * This rule checks if the input, as a number, is within a range. If the number is not in the range, an error will be created.
-         * 
+         *
+         * Does not support array values (e.g. `multi-select`) — the comparison
+         * (`$value < $min`) expects a scalar.
+         *
          * @param float $min Min allowed value
          * @param float $max Max allowed value
          * @return Field Returns itself to allow chaining
@@ -196,9 +213,12 @@
 
         /**
          * Adds a date rule
-         * 
-         * This rule checks if the input value adheres to a given date format
-         * 
+         *
+         * This rule checks if the input value adheres to a given date format.
+         *
+         * Does not support array values (e.g. `multi-select`) — `strtotime()`
+         * expects a scalar.
+         *
          * @param string $format The tested date format
          * @return Field Returns itself to allow chaining
          */
@@ -232,7 +252,10 @@
 
         /**
          * Adds a regular expression rule to the field
-         * 
+         *
+         * For array-valued fields (e.g. `multi-select`) the regex is applied
+         * per item; the field fails as soon as any single item fails.
+         *
          * @param string $expression The regex expression
          * @param string[] $exceptions An array of characters to be excluded from the regex
          * @return Field Returns itself to allow chaining

--- a/src/Message/Response.php
+++ b/src/Message/Response.php
@@ -415,7 +415,9 @@
                 if($field->dbField == $pkField && $field->value == $pkValue) continue;
 
                 $fields[] = $field->dbField;
-                $values[] = $field->value;
+                // Array values (e.g. from multi-select) are stored as JSON;
+                // mysqli bind_param can't bind a PHP array directly.
+                $values[] = is_array($field->value) ? json_encode($field->value) : $field->value;
                 $types .= $field->dataType;
             }
 
@@ -470,7 +472,9 @@
                 $sqlParams[] = ("`" . $field->dbField . "`");
                 $sqlValues[] = "?";
                 $types .= $field->dataType;
-                $vals[] = $field->value;
+                // Array values (e.g. from multi-select) are stored as JSON;
+                // mysqli bind_param can't bind a PHP array directly.
+                $vals[] = is_array($field->value) ? json_encode($field->value) : $field->value;
             }
 
             $sqlCmdParams = implode(",", $sqlParams);

--- a/tests/e2e/app/Controllers/FormController.php
+++ b/tests/e2e/app/Controllers/FormController.php
@@ -310,5 +310,80 @@
             return $res->json($result === false);
         }
 
+        public function action_validationMultiSelect(Request $req, Response $res) {
+            if($req->hasFormData()) {
+                $formResult = $req->validateForm([
+                    (new FormField("field_multi_select", "value_json")),
+                    (new FormField("field_multi_select_required", "value"))
+                        ->required()
+                ]);
+
+                if($formResult->hasErrors) {
+                    return $res->formErrors($formResult->errors);
+                }
+
+                $insertId = $res->insertDatabase("model_test_insert", $formResult);
+
+                return $res->success([
+                    "id" => $insertId,
+                    "values_only" => $req->getPost("field_multi_select_values_only"),
+                    "text_only" => $req->getPost("field_multi_select_text_only"),
+                    "both" => $req->getPost("field_multi_select"),
+                    "required" => $req->getPost("field_multi_select_required"),
+                ]);
+            }
+
+            return $res->render("form/validationMultiSelect", [
+                "exampleData" => $this->makeFood([
+                    ["id" => "one",   "label" => "One"],
+                    ["id" => "two",   "label" => "Two"],
+                    ["id" => "three", "label" => "Three"],
+                ], "id", "label"),
+            ]);
+        }
+
+        // Probe for the list-aware variants of length/regex and the new
+        // ->in() allow-list rule. length and regex now accept array field
+        // values (multi-select); ->in() applies an in-memory allow-list
+        // and works for both scalar select and array multi-select.
+        // No DB persistence here, just validation echoed back as JSON.
+        public function action_validationListRules(Request $req, Response $res) {
+            if($req->hasFormData()) {
+                $formResult = $req->validateForm([
+                    (new FormField("field_list_length"))
+                        ->length(1, 2),
+                    (new FormField("field_list_regex"))
+                        ->regex("/^[a-z]+$/"),
+                    (new FormField("field_list_in_array"))
+                        ->in(["one", "two"]),
+                    (new FormField("field_list_in_select"))
+                        ->in(["one", "two"]),
+                    // Per-item DB check on a multi-select: every picked
+                    // role name must exist in z_role.
+                    (new FormField("field_list_exists_multi"))
+                        ->exists("z_role", "name"),
+                ]);
+
+                if($formResult->hasErrors) {
+                    return $res->formErrors($formResult->errors);
+                }
+
+                return $res->success();
+            }
+
+            return $res->render("form/validationListRules", [
+                "options" => $this->makeFood([
+                    ["id" => "one",   "label" => "One"],
+                    ["id" => "two",   "label" => "Two"],
+                    ["id" => "three", "label" => "Three"],
+                ], "id", "label"),
+                "mixedCase" => $this->makeFood([
+                    ["id" => "abc", "label" => "abc"],
+                    ["id" => "def", "label" => "def"],
+                    ["id" => "XYZ", "label" => "XYZ"],
+                ], "id", "label"),
+            ]);
+        }
+
     }
 ?>

--- a/tests/e2e/app/Database/migrations/2025-11-16_Form.sql
+++ b/tests/e2e/app/Database/migrations/2025-11-16_Form.sql
@@ -12,7 +12,8 @@ INSERT INTO `duplicate` (`value`) VALUES
 
 CREATE TABLE `model_test_insert` (
     `id` INT PRIMARY KEY AUTO_INCREMENT NOT NULL,
-    `value` VARCHAR(255) NOT NULL
+    `value` VARCHAR(255) NULL DEFAULT NULL,
+    `value_json` JSON NULL DEFAULT NULL
 );
 
 CREATE TABLE `model_test_select` (

--- a/tests/e2e/app/Views/form/validationListRules.php
+++ b/tests/e2e/app/Views/form/validationListRules.php
@@ -1,0 +1,46 @@
+<?php return [ "body" => function($opt) { ?>
+    <div id="form" data-test="form"></div>
+
+    <script>
+        var form = Z.Forms.create({ dom: "form" });
+
+        form.createField({
+            name: "field_list_length",
+            type: "multi-select",
+            text: "Length 1..2",
+            food: <?= $opt["options"] ?>,
+        });
+
+        form.createField({
+            name: "field_list_regex",
+            type: "multi-select",
+            text: "Lowercase-only regex (per item)",
+            food: <?= $opt["mixedCase"] ?>,
+        });
+
+        form.createField({
+            name: "field_list_in_array",
+            type: "multi-select",
+            text: "Allow-list ->in (multi-select)",
+            food: <?= $opt["options"] ?>,
+        });
+
+        form.createField({
+            name: "field_list_in_select",
+            type: "select",
+            text: "Allow-list ->in (plain select)",
+            food: <?= $opt["options"] ?>,
+        });
+
+        form.createField({
+            name: "field_list_exists_multi",
+            type: "multi-select",
+            text: "DB exists ->exists (multi-select)",
+            food: [
+                { value: "fwapi_KnownRole", text: "fwapi_KnownRole" },
+                { value: "fwapi_RoleState", text: "fwapi_RoleState" },
+                { value: "NoSuchRole_NotSeeded", text: "NoSuchRole_NotSeeded" },
+            ],
+        });
+    </script>
+<?php }]; ?>

--- a/tests/e2e/app/Views/form/validationMultiSelect.php
+++ b/tests/e2e/app/Views/form/validationMultiSelect.php
@@ -1,0 +1,92 @@
+<?php return [ "body" => function($opt) { ?>
+    <div id="form" data-test="form"></div>
+
+    <script>
+        var form = Z.Forms.create({
+            dom: "form",
+        });
+
+        form.createField({
+            name: "field_multi_select_values_only",
+            type: "multi-select",
+            text: "Values Only",
+            food: [
+                { value: "one" },
+                { value: "two" },
+                { value: "three" },
+            ],
+        });
+
+        form.createField({
+            name: "field_multi_select_text_only",
+            type: "multi-select",
+            text: "Text Only",
+            food: [
+                { text: "One" },
+                { text: "Two" },
+                { text: "Three" },
+            ],
+        });
+
+        form.createField({
+            name: "field_multi_select",
+            type: "multi-select",
+            text: "Values + Text",
+            food: <?= $opt["exampleData"] ?>,
+        });
+
+        form.createField({
+            name: "field_multi_select_required",
+            type: "multi-select",
+            text: "Required",
+            required: true,
+            food: <?= $opt["exampleData"] ?>,
+        });
+
+        form.createField({
+            name: "field_multi_select_preloaded",
+            type: "multi-select",
+            text: "Pre-loaded (inline array)",
+            food: <?= $opt["exampleData"] ?>,
+            value: ["one", "three"],
+        });
+
+        form.createField({
+            name: "field_multi_select_preloaded_json",
+            type: "multi-select",
+            text: "Pre-loaded (json_encode'd)",
+            food: <?= $opt["exampleData"] ?>,
+            value: <?= json_encode(["two"]) ?>,
+        });
+
+        form.createField({
+            name: "field_multi_select_placeholder",
+            type: "multi-select",
+            text: "Placeholder",
+            placeholder: "Pick one...",
+            food: <?= $opt["exampleData"] ?>,
+        });
+
+        form.createField({
+            name: "field_multi_select_default",
+            type: "multi-select",
+            text: "Default",
+            food: <?= $opt["exampleData"] ?>,
+            default: ["two"],
+        });
+
+        form.createField({
+            name: "field_multi_select_optgroup",
+            type: "multi-select",
+            text: "Optgroups",
+            food: [
+                { type: "optgroup", text: "Numbers" },
+                { value: "one", text: "One" },
+                { value: "two", text: "Two" },
+                { type: "optgroup", text: "Letters" },
+                { value: "a", text: "Alpha" },
+                { value: "b", text: "Bravo" },
+            ],
+        });
+    </script>
+<?php }]; ?>

--- a/tests/e2e/tests/cypress/e2e/form/list-rules.cy.js
+++ b/tests/e2e/tests/cypress/e2e/form/list-rules.cy.js
@@ -1,0 +1,223 @@
+// Coverage for the array-aware variants of length / regex / exists and
+// the new ->in() allow-list rule.
+//
+// length: counts items when the value is an array.
+// regex:  applied per item; field fails if any item fails.
+// exists: original (table, field) check still works on scalar AND array
+//         field values (per-item DB check).
+// in:     new rule, value(s) must appear in an in-memory allow-list.
+//         Per-item for arrays. Works for both plain select and
+//         multi-select. Guards against tampered POST payloads.
+
+describe('Form List-aware rules', () => {
+    before(() => {
+        cy.dbSeed();
+    });
+
+    beforeEach(() => {
+        cy.visit('/Form/validationListRules');
+    });
+
+    describe('length() on arrays counts items', () => {
+        it('Submitting one selection satisfies length(1, 2)', () => {
+            cy.intercept('POST', '/Form/validationListRules').as('submit');
+
+            cy.form('field_list_length').select('one');
+            cy.form('field_list_in_array').select('one');
+            cy.form('field_list_in_select').select('one');
+            cy.query('form').find('button').click();
+
+            cy.wait('@submit').then((interception) => {
+                const json = JSON.parse(interception.response.body);
+                expect(json.result).to.eq('success');
+            });
+        });
+
+        it('Submitting three selections trips length(1, 2)', () => {
+            cy.intercept('POST', '/Form/validationListRules').as('submit');
+
+            cy.form('field_list_length').select('one');
+            cy.form('field_list_length').select('two');
+            cy.form('field_list_length').select('three');
+            cy.form('field_list_in_array').select('one');
+            cy.form('field_list_in_select').select('one');
+            cy.query('form').find('button').click();
+
+            cy.wait('@submit').then((interception) => {
+                const json = JSON.parse(interception.response.body);
+                expect(json.result).to.eq('formErrors');
+                expect(json.formErrors).to.satisfy((errs) =>
+                    errs.some((e) => e.name === 'field_list_length' && e.type === 'length')
+                );
+            });
+        });
+    });
+
+    describe('regex() on arrays runs per item', () => {
+        it('All lowercase items pass the per-item regex', () => {
+            cy.intercept('POST', '/Form/validationListRules').as('submit');
+
+            cy.form('field_list_regex').select('abc');
+            cy.form('field_list_regex').select('def');
+            cy.form('field_list_in_array').select('one');
+            cy.form('field_list_in_select').select('one');
+            cy.query('form').find('button').click();
+
+            cy.wait('@submit').then((interception) => {
+                const json = JSON.parse(interception.response.body);
+                expect(json.result).to.eq('success');
+            });
+        });
+
+        it('A single mixed-case item is enough to fail the per-item regex', () => {
+            cy.intercept('POST', '/Form/validationListRules').as('submit');
+
+            cy.form('field_list_regex').select('abc');
+            cy.form('field_list_regex').select('XYZ');
+            cy.form('field_list_in_array').select('one');
+            cy.form('field_list_in_select').select('one');
+            cy.query('form').find('button').click();
+
+            cy.wait('@submit').then((interception) => {
+                const json = JSON.parse(interception.response.body);
+                expect(json.result).to.eq('formErrors');
+                expect(json.formErrors).to.satisfy((errs) =>
+                    errs.some((e) => e.name === 'field_list_regex' && e.type === 'regex')
+                );
+            });
+        });
+    });
+
+    describe('in() on multi-select', () => {
+        it('Picking values from the allow-list succeeds', () => {
+            cy.intercept('POST', '/Form/validationListRules').as('submit');
+
+            cy.form('field_list_in_array').select('one');
+            cy.form('field_list_in_array').select('two');
+            cy.form('field_list_in_select').select('one');
+            cy.query('form').find('button').click();
+
+            cy.wait('@submit').then((interception) => {
+                const json = JSON.parse(interception.response.body);
+                expect(json.result).to.eq('success');
+            });
+        });
+
+        it('Picking a value outside the allow-list fails', () => {
+            cy.intercept('POST', '/Form/validationListRules').as('submit');
+
+            // "three" is in the dropdown but not in the allow-list ["one","two"].
+            cy.form('field_list_in_array').select('three');
+            cy.form('field_list_in_select').select('one');
+            cy.query('form').find('button').click();
+
+            cy.wait('@submit').then((interception) => {
+                const json = JSON.parse(interception.response.body);
+                expect(json.result).to.eq('formErrors');
+                expect(json.formErrors).to.satisfy((errs) =>
+                    errs.some((e) => e.name === 'field_list_in_array' && e.type === 'in')
+                );
+            });
+        });
+
+        it('Mixing one allowed and one disallowed pick still fails (per-item check)', () => {
+            cy.intercept('POST', '/Form/validationListRules').as('submit');
+
+            cy.form('field_list_in_array').select('one');
+            cy.form('field_list_in_array').select('three');
+            cy.form('field_list_in_select').select('one');
+            cy.query('form').find('button').click();
+
+            cy.wait('@submit').then((interception) => {
+                const json = JSON.parse(interception.response.body);
+                expect(json.result).to.eq('formErrors');
+                expect(json.formErrors).to.satisfy((errs) =>
+                    errs.some((e) => e.name === 'field_list_in_array' && e.type === 'in')
+                );
+            });
+        });
+    });
+
+    describe('exists() per item on multi-select', () => {
+        it('Picking only DB-existing role names succeeds', () => {
+            cy.intercept('POST', '/Form/validationListRules').as('submit');
+
+            cy.form('field_list_exists_multi').select('fwapi_KnownRole');
+            cy.form('field_list_exists_multi').select('fwapi_RoleState');
+            cy.form('field_list_in_array').select('one');
+            cy.form('field_list_in_select').select('one');
+            cy.query('form').find('button').click();
+
+            cy.wait('@submit').then((interception) => {
+                const json = JSON.parse(interception.response.body);
+                expect(json.result).to.eq('success');
+            });
+        });
+
+        it('Picking a non-existing role name fails', () => {
+            cy.intercept('POST', '/Form/validationListRules').as('submit');
+
+            cy.form('field_list_exists_multi').select('NoSuchRole_NotSeeded');
+            cy.form('field_list_in_array').select('one');
+            cy.form('field_list_in_select').select('one');
+            cy.query('form').find('button').click();
+
+            cy.wait('@submit').then((interception) => {
+                const json = JSON.parse(interception.response.body);
+                expect(json.result).to.eq('formErrors');
+                expect(json.formErrors).to.satisfy((errs) =>
+                    errs.some((e) => e.name === 'field_list_exists_multi' && e.type === 'exist')
+                );
+            });
+        });
+
+        it('Mixing one existing and one non-existing role fails (per-item check)', () => {
+            cy.intercept('POST', '/Form/validationListRules').as('submit');
+
+            cy.form('field_list_exists_multi').select('fwapi_KnownRole');
+            cy.form('field_list_exists_multi').select('NoSuchRole_NotSeeded');
+            cy.form('field_list_in_array').select('one');
+            cy.form('field_list_in_select').select('one');
+            cy.query('form').find('button').click();
+
+            cy.wait('@submit').then((interception) => {
+                const json = JSON.parse(interception.response.body);
+                expect(json.result).to.eq('formErrors');
+                expect(json.formErrors).to.satisfy((errs) =>
+                    errs.some((e) => e.name === 'field_list_exists_multi' && e.type === 'exist')
+                );
+            });
+        });
+    });
+
+    describe('in() on plain select', () => {
+        it('Picking an allowed value succeeds', () => {
+            cy.intercept('POST', '/Form/validationListRules').as('submit');
+
+            cy.form('field_list_in_array').select('one');
+            cy.form('field_list_in_select').select('two');
+            cy.query('form').find('button').click();
+
+            cy.wait('@submit').then((interception) => {
+                const json = JSON.parse(interception.response.body);
+                expect(json.result).to.eq('success');
+            });
+        });
+
+        it('Picking a value outside the allow-list fails', () => {
+            cy.intercept('POST', '/Form/validationListRules').as('submit');
+
+            cy.form('field_list_in_array').select('one');
+            cy.form('field_list_in_select').select('three');
+            cy.query('form').find('button').click();
+
+            cy.wait('@submit').then((interception) => {
+                const json = JSON.parse(interception.response.body);
+                expect(json.result).to.eq('formErrors');
+                expect(json.formErrors).to.satisfy((errs) =>
+                    errs.some((e) => e.name === 'field_list_in_select' && e.type === 'in')
+                );
+            });
+        });
+    });
+});

--- a/tests/e2e/tests/cypress/e2e/form/multi-select.cy.js
+++ b/tests/e2e/tests/cypress/e2e/form/multi-select.cy.js
@@ -1,0 +1,433 @@
+// Coverage for the multi-select field type in Z.js. The view at
+// Views/form/validationMultiSelect.php renders three fields covering
+// the three food shapes (values only, text only, value+text), and the
+// controller persists the value+text one to model_test_insert.value_json.
+
+describe('Form Multi Select', () => {
+    before(() => {
+        cy.dbSeed();
+    });
+
+    beforeEach(() => {
+        cy.visit('/Form/validationMultiSelect');
+    });
+
+    it('renders one option per food entry (placeholder excluded)', () => {
+        cy.form('field_multi_select_values_only').find('option').should('have.length', 4);
+        cy.form('field_multi_select_text_only').find('option').should('have.length', 4);
+        cy.form('field_multi_select').find('option').should('have.length', 4);
+    });
+
+    describe('Display behavior', () => {
+        it('Values only: option text falls back to the value', () => {
+            cy.form('field_multi_select_values_only').find('option')
+                .eq(1).should('have.value', 'one').and('contain.text', 'one');
+
+            cy.form('field_multi_select_values_only').select('two');
+            cy.form('field_multi_select_values_only')
+                .parent().find('[data-value="two"]').should('contain.text', 'two');
+        });
+
+        it('Text only: text is used as the value', () => {
+            cy.form('field_multi_select_text_only').find('option')
+                .eq(1).should('have.value', 'One').and('contain.text', 'One');
+
+            cy.form('field_multi_select_text_only').select('One');
+            cy.form('field_multi_select_text_only')
+                .parent().find('[data-value="One"]').should('contain.text', 'One');
+        });
+
+        it('Value + text: badge shows text, value stays separate', () => {
+            cy.form('field_multi_select').find('option')
+                .eq(1).should('have.value', 'one').and('contain.text', 'One');
+
+            cy.form('field_multi_select').select('one');
+            cy.form('field_multi_select')
+                .parent().find('[data-value="one"]').should('contain.text', 'One');
+        });
+    });
+
+    describe('Selection management', () => {
+        it('Selecting an option resets the dropdown to placeholder', () => {
+            cy.form('field_multi_select').select('one');
+            cy.form('field_multi_select').should('have.value', '');
+        });
+
+        it('Selecting the same option twice does not add a duplicate badge', () => {
+            cy.form('field_multi_select').select('one');
+            cy.form('field_multi_select').select('one');
+            cy.form('field_multi_select')
+                .parent().find('[data-value="one"]').should('have.length', 1);
+        });
+
+        it('Clicking a badge unselects that value', () => {
+            cy.form('field_multi_select').select('one');
+            cy.form('field_multi_select').select('two');
+            cy.form('field_multi_select')
+                .parent().find('[data-value]').should('have.length', 2);
+
+            cy.form('field_multi_select')
+                .parent().find('[data-value="one"]').click();
+            cy.form('field_multi_select')
+                .parent().find('[data-value="one"]').should('not.exist');
+            cy.form('field_multi_select')
+                .parent().find('[data-value="two"]').should('exist');
+        });
+
+        it('Selected options disappear from the dropdown and return on unselect', () => {
+            cy.form('field_multi_select').find('option:not([hidden])').should('have.length', 4);
+
+            cy.form('field_multi_select').select('one');
+            cy.form('field_multi_select').find('option:not([hidden])').should('have.length', 3);
+            cy.form('field_multi_select').find('option[value="one"]').should('have.attr', 'hidden');
+
+            cy.form('field_multi_select').select('two');
+            cy.form('field_multi_select').find('option:not([hidden])').should('have.length', 2);
+
+            cy.form('field_multi_select')
+                .parent().find('[data-value="one"]').click();
+            cy.form('field_multi_select').find('option:not([hidden])').should('have.length', 3);
+            cy.form('field_multi_select').find('option[value="one"]').should('not.have.attr', 'hidden');
+        });
+
+        it('form.reset() also restores every option back into the dropdown', () => {
+            cy.form('field_multi_select').select('one');
+            cy.form('field_multi_select').select('two');
+            cy.form('field_multi_select').find('option:not([hidden])').should('have.length', 2);
+
+            cy.window().then((win) => {
+                win.form.fields.field_multi_select.reset();
+            });
+
+            cy.form('field_multi_select').find('option:not([hidden])').should('have.length', 4);
+        });
+
+        it('form.reset() clears all selected badges', () => {
+            cy.form('field_multi_select').select('one');
+            cy.form('field_multi_select').select('two');
+
+            cy.window().then((win) => {
+                win.form.reset();
+            });
+
+            cy.form('field_multi_select')
+                .parent().find('[data-value]').should('have.length', 0);
+        });
+    });
+
+    describe('Value getter / setter', () => {
+        it('value getter returns the selected values as an array', () => {
+            cy.form('field_multi_select').select('one');
+            cy.form('field_multi_select').select('three');
+
+            cy.window().then((win) => {
+                expect(win.form.fields.field_multi_select.value)
+                    .to.deep.eq(['one', 'three']);
+            });
+        });
+
+        it('value getter returns an empty array when no items are selected', () => {
+            cy.window().then((win) => {
+                expect(win.form.fields.field_multi_select.value).to.deep.eq([]);
+            });
+        });
+
+        it('value setter (array) populates badges using the food map for text', () => {
+            cy.window().then((win) => {
+                win.form.fields.field_multi_select.value = ['two', 'three'];
+            });
+
+            cy.form('field_multi_select')
+                .parent().find('[data-value="two"]').should('contain.text', 'Two');
+            cy.form('field_multi_select')
+                .parent().find('[data-value="three"]').should('contain.text', 'Three');
+        });
+
+        it('value setter ignores non-array input (e.g. JSON string)', () => {
+            cy.form('field_multi_select').select('one');
+
+            cy.window().then((win) => {
+                win.form.fields.field_multi_select.value = '["two","three"]';
+            });
+
+            cy.form('field_multi_select')
+                .parent().find('[data-value]').should('have.length', 0);
+        });
+    });
+
+    describe('Submission', () => {
+        it('Posts each multi-select as a native PHP array (name[]=value)', () => {
+            cy.intercept('POST', '/Form/validationMultiSelect').as('submit');
+
+            cy.form('field_multi_select_values_only').select('one');
+            cy.form('field_multi_select_text_only').select('Two');
+            cy.form('field_multi_select').select('three');
+            // Required field must be filled or the whole submission rejects.
+            cy.form('field_multi_select_required').select('one');
+
+            cy.query('form').find('button').click();
+
+            cy.wait('@submit').then((interception) => {
+                const body = interception.response.body;
+                const json = typeof body === 'string' ? JSON.parse(body) : body;
+                expect(json.result).to.eq('success');
+                expect(json.values_only).to.deep.eq(['one']);
+                expect(json.text_only).to.deep.eq(['Two']);
+                expect(json.both).to.deep.eq(['three']);
+                expect(json.required).to.deep.eq(['one']);
+            });
+        });
+
+        it('Posts multiple selections as a multi-element array', () => {
+            cy.intercept('POST', '/Form/validationMultiSelect').as('submit');
+
+            cy.form('field_multi_select').select('one');
+            cy.form('field_multi_select').select('three');
+            cy.form('field_multi_select_required').select('two');
+
+            cy.query('form').find('button').click();
+
+            cy.wait('@submit').then((interception) => {
+                const body = interception.response.body;
+                const json = typeof body === 'string' ? JSON.parse(body) : body;
+                expect(json.result).to.eq('success');
+                expect(json.both).to.deep.eq(['one', 'three']);
+            });
+        });
+
+        it('Persists the value+text selection to value_json via insertDatabase', () => {
+            cy.form('field_multi_select').select('one');
+            cy.form('field_multi_select').select('two');
+            cy.form('field_multi_select_required').select('one');
+
+            cy.query('form').find('button').click();
+            cy.query('form').contains('Saved!');
+        });
+
+        it('Omits empty optional multi-selects from the submission entirely', () => {
+            cy.intercept('POST', '/Form/validationMultiSelect').as('submit');
+
+            cy.form('field_multi_select_required').select('one');
+            cy.query('form').find('button').click();
+
+            cy.wait('@submit').then((interception) => {
+                const body = interception.response.body;
+                const json = typeof body === 'string' ? JSON.parse(body) : body;
+                expect(json.result).to.eq('success');
+                // Empty multi-selects aren't in $_POST at all -> getPost() -> null.
+                expect(json.values_only).to.eq(null);
+                expect(json.text_only).to.eq(null);
+                expect(json.both).to.eq(null);
+                expect(json.required).to.deep.eq(['one']);
+            });
+        });
+    });
+
+    describe('Required', () => {
+        it('Renders a red asterisk on the required field label', () => {
+            cy.form('field_multi_select_required')
+                .parents('.col').find('label .text-danger').should('contain.text', '*');
+        });
+
+        it('Submitting with the required field empty returns a required form error', () => {
+            cy.intercept('POST', '/Form/validationMultiSelect').as('submit');
+
+            cy.query('form').find('button').click();
+
+            cy.wait('@submit').then((interception) => {
+                const body = interception.response.body;
+                const json = typeof body === 'string' ? JSON.parse(body) : body;
+                expect(json.result).to.eq('formErrors');
+                expect(json.formErrors).to.satisfy((errs) =>
+                    errs.some((e) =>
+                        e.name === 'field_multi_select_required' && e.type === 'required'
+                    )
+                );
+            });
+        });
+
+        it('Filling the required field clears the error and the submission succeeds', () => {
+            cy.form('field_multi_select_required').select('two');
+
+            cy.query('form').find('button').click();
+            cy.query('form').contains('Saved!');
+        });
+
+        it('Removing the only selected badge re-empties a required multi-select', () => {
+            cy.intercept('POST', '/Form/validationMultiSelect').as('submit');
+
+            cy.form('field_multi_select_required').select('one');
+            cy.form('field_multi_select_required')
+                .parent().find('[data-value="one"]').click();
+
+            cy.query('form').find('button').click();
+
+            cy.wait('@submit').then((interception) => {
+                const body = interception.response.body;
+                const json = typeof body === 'string' ? JSON.parse(body) : body;
+                expect(json.result).to.eq('formErrors');
+            });
+        });
+    });
+
+    describe('Placeholder', () => {
+        it('Uses the placeholder text as the first option (replaces "---")', () => {
+            cy.form('field_multi_select_placeholder')
+                .find('option').eq(0)
+                .should('have.value', '').and('contain.text', 'Pick one...');
+        });
+
+        it('Falls back to "---" when no placeholder is given', () => {
+            cy.form('field_multi_select')
+                .find('option').eq(0)
+                .should('have.value', '').and('contain.text', '---');
+        });
+    });
+
+    describe('Default value', () => {
+        it('default: [...] pre-fills the badges on first render', () => {
+            cy.form('field_multi_select_default')
+                .parent().find('[data-value]').should('have.length', 1);
+            cy.form('field_multi_select_default')
+                .parent().find('[data-value="two"]').should('contain.text', 'Two');
+        });
+
+        it('reset() restores the default selection (not just an empty list)', () => {
+            cy.form('field_multi_select_default').select('one');
+            cy.form('field_multi_select_default')
+                .parent().find('[data-value]').should('have.length', 2);
+
+            cy.window().then((win) => {
+                win.form.fields.field_multi_select_default.reset();
+            });
+
+            cy.form('field_multi_select_default')
+                .parent().find('[data-value]').should('have.length', 1);
+            cy.form('field_multi_select_default')
+                .parent().find('[data-value="two"]').should('exist');
+        });
+
+        it('reset() also re-hides the default option from the dropdown', () => {
+            // Default ["two"] should be hidden in the dropdown on load.
+            cy.form('field_multi_select_default')
+                .find('option[value="two"]').should('have.attr', 'hidden');
+
+            cy.form('field_multi_select_default')
+                .parent().find('[data-value="two"]').click();
+            cy.form('field_multi_select_default')
+                .find('option[value="two"]').should('not.have.attr', 'hidden');
+
+            cy.window().then((win) => {
+                win.form.fields.field_multi_select_default.reset();
+            });
+
+            cy.form('field_multi_select_default')
+                .find('option[value="two"]').should('have.attr', 'hidden');
+        });
+    });
+
+    describe('Optgroups', () => {
+        it('Builds an <optgroup> for each food optgroup entry', () => {
+            cy.form('field_multi_select_optgroup').find('optgroup').should('have.length', 2);
+            cy.form('field_multi_select_optgroup')
+                .find('optgroup').eq(0).should('have.attr', 'label', 'Numbers');
+            cy.form('field_multi_select_optgroup')
+                .find('optgroup').eq(1).should('have.attr', 'label', 'Letters');
+        });
+
+        it('Groups subsequent option entries under the preceding optgroup', () => {
+            cy.form('field_multi_select_optgroup')
+                .find('optgroup[label="Numbers"] option').should('have.length', 2);
+            cy.form('field_multi_select_optgroup')
+                .find('optgroup[label="Letters"] option').should('have.length', 2);
+        });
+
+        it('Selection still works for grouped options (badge shows the option text)', () => {
+            cy.form('field_multi_select_optgroup').select('a');
+            cy.form('field_multi_select_optgroup')
+                .parent().find('[data-value="a"]').should('contain.text', 'Alpha');
+        });
+
+        it('Hides the optgroup once every option under it has been picked', () => {
+            cy.form('field_multi_select_optgroup').select('one');
+            cy.form('field_multi_select_optgroup')
+                .find('optgroup[label="Numbers"]').should('not.have.attr', 'hidden');
+
+            cy.form('field_multi_select_optgroup').select('two');
+            cy.form('field_multi_select_optgroup')
+                .find('optgroup[label="Numbers"]').should('have.attr', 'hidden');
+
+            // The other group is untouched.
+            cy.form('field_multi_select_optgroup')
+                .find('optgroup[label="Letters"]').should('not.have.attr', 'hidden');
+        });
+
+        it('Restores the optgroup when an option underneath is unselected again', () => {
+            cy.form('field_multi_select_optgroup').select('one');
+            cy.form('field_multi_select_optgroup').select('two');
+            cy.form('field_multi_select_optgroup')
+                .find('optgroup[label="Numbers"]').should('have.attr', 'hidden');
+
+            cy.form('field_multi_select_optgroup')
+                .parent().find('[data-value="one"]').click();
+            cy.form('field_multi_select_optgroup')
+                .find('optgroup[label="Numbers"]').should('not.have.attr', 'hidden');
+        });
+    });
+
+    describe('Disabled lock (PR 143 compat)', () => {
+        it('A disabled multi-select ignores badge-click removals', () => {
+            cy.form('field_multi_select').select('one');
+            cy.form('field_multi_select').select('two');
+
+            cy.window().then((win) => {
+                // PR 143 introduces field.isDisabled(); stub it until merged.
+                win.form.fields.field_multi_select.isDisabled = () => true;
+            });
+
+            cy.form('field_multi_select')
+                .parent().find('[data-value="one"]').click();
+
+            cy.form('field_multi_select')
+                .parent().find('[data-value="one"]').should('exist');
+            cy.form('field_multi_select')
+                .parent().find('[data-value]').should('have.length', 2);
+        });
+    });
+
+    describe('Pre-loaded value', () => {
+        it('value: [...] populates badges on page load with text from food map', () => {
+            cy.form('field_multi_select_preloaded')
+                .parent().find('[data-value]').should('have.length', 2);
+            cy.form('field_multi_select_preloaded')
+                .parent().find('[data-value="one"]').should('contain.text', 'One');
+            cy.form('field_multi_select_preloaded')
+                .parent().find('[data-value="three"]').should('contain.text', 'Three');
+        });
+
+        it('value: <?= json_encode(...) ?> populates badges on page load', () => {
+            cy.form('field_multi_select_preloaded_json')
+                .parent().find('[data-value]').should('have.length', 1);
+            cy.form('field_multi_select_preloaded_json')
+                .parent().find('[data-value="two"]').should('contain.text', 'Two');
+        });
+
+        it('Pre-loaded values are reflected in the field value getter', () => {
+            cy.window().then((win) => {
+                expect(win.form.fields.field_multi_select_preloaded.value)
+                    .to.deep.eq(['one', 'three']);
+                expect(win.form.fields.field_multi_select_preloaded_json.value)
+                    .to.deep.eq(['two']);
+            });
+        });
+
+        it('Pre-loaded values can still be unselected by clicking the badge', () => {
+            cy.form('field_multi_select_preloaded')
+                .parent().find('[data-value="one"]').click();
+            cy.form('field_multi_select_preloaded')
+                .parent().find('[data-value]').should('have.length', 1);
+            cy.form('field_multi_select_preloaded')
+                .parent().find('[data-value="three"]').should('exist');
+        });
+    });
+});

--- a/web/Z.js
+++ b/web/Z.js
@@ -999,7 +999,7 @@ class ZForm {
 
 /**
  * Types to use in an input field. All html default ones, textarea, select and autocomplete are supported.
- * @typedef {"button"|"checkbox"|"color"|"date"|"datetime-local"|"email"|"file"|"hidden"|"image"|"month"|"number"|"password"|"radio"|"range"|"reset"|"search"|"submit"|"tel"|"text"|"time"|"url"|"week"|"select"|"textarea"|"autocomplete"} InputType
+ * @typedef {"button"|"checkbox"|"color"|"date"|"datetime-local"|"email"|"file"|"hidden"|"image"|"month"|"number"|"password"|"radio"|"range"|"reset"|"search"|"submit"|"tel"|"text"|"time"|"url"|"week"|"select"|"multi-select"|"textarea"|"autocomplete"} InputType
  */
 
 /**
@@ -1095,6 +1095,33 @@ class ZFormField {
       }
       this.input.classList.add("form-control");
       this.input.appendChild(option);
+    } else if (this.type == "multi-select") {     // --- Multi Select ---
+      // Visible <select> the user picks from; badges below show the
+      // chosen entries and the submitted value is a JSON array.
+      customDiv = document.createElement("div");
+
+      this.input = document.createElement("select");
+      this.input.classList.add("form-control");
+      this.placeholderOption = document.createElement("option");
+      this.placeholderOption.setAttribute("value", "");
+      this.placeholderOption.innerHTML = this.placeholder || "---";
+      this.input.appendChild(this.placeholderOption);
+      customDiv.appendChild(this.input);
+
+      this.badgeContainer = document.createElement("div");
+      this.badgeContainer.classList.add("mt-2");
+      customDiv.appendChild(this.badgeContainer);
+
+      this.foodMap = {};
+      this.optionMap = {};
+      this.selectedValues = [];
+
+      this.input.addEventListener("change", () => {
+        var pick = this.input.value;
+        if (pick === "") return;
+        this.addSelectedValue(pick);
+        this.input.value = "";
+      });
     } else if (this.type == "textarea") {         // --- Textarea ---
       this.input = document.createElement("textarea");
       this.input.classList.add("form-control");
@@ -1262,10 +1289,19 @@ class ZFormField {
    * @type {any}
    */
   get value() {
+    if (this.type == "multi-select") {
+      return this.selectedValues.slice();
+    }
     return this.input.value;
   }
 
   set value(value) {
+    if (this.type == "multi-select") {
+      var arr = Array.isArray(value) ? value : [];
+      this.clearSelectedValues();
+      for (var v of arr) this.addSelectedValue(String(v));
+      return;
+    }
     if (this.input.type != "file") {
       this.input.value = value;
     } else {
@@ -1275,6 +1311,76 @@ class ZFormField {
         this.fileValue.innerText = value;
       }
     }
+  }
+
+  /**
+   * Adds a value to a multi-select. Creates the removable badge and keeps
+   * the internal selected-list in sync. Duplicates are ignored.
+   * @param {string} value Value to add
+   * @returns {void}
+   */
+  addSelectedValue(value) {
+    if (this.selectedValues.includes(value)) return;
+    this.selectedValues.push(value);
+
+    var option = this.optionMap[value];
+    if (option) {
+      option.hidden = true;
+      this._updateOptgroupVisibility(option.parentElement);
+    }
+
+    var text = this.foodMap[value] !== undefined ? this.foodMap[value] : value;
+    var badge = document.createElement("span");
+    badge.classList.add("badge", "badge-primary", "mr-1", "mb-1", "p-2");
+    badge.style.cursor = "pointer";
+    badge.setAttribute("data-value", value);
+    badge.innerHTML = "&times; " + text;
+    badge.addEventListener("click", () => {
+      // Honor PR 143's field.disable() — a disabled multi-select must not
+      // let badges be removed either. typeof-guarded so this still works
+      // pre-PR-143.
+      if (typeof this.isDisabled === "function" && this.isDisabled()) return;
+
+      var idx = this.selectedValues.indexOf(value);
+      if (idx >= 0) this.selectedValues.splice(idx, 1);
+      if (option) {
+        option.hidden = false;
+        this._updateOptgroupVisibility(option.parentElement);
+      }
+      badge.remove();
+      this.input.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+    this.badgeContainer.appendChild(badge);
+  }
+
+  /**
+   * Clears all selected values from a multi-select. Restores every option
+   * (and any collapsed optgroups) back into the dropdown.
+   * @returns {void}
+   */
+  clearSelectedValues() {
+    this.selectedValues = [];
+    this.badgeContainer.innerHTML = "";
+    for (var k in this.optionMap) {
+      this.optionMap[k].hidden = false;
+    }
+    // Optgroups follow their children's visibility — restore any that
+    // were collapsed when all their options were hidden.
+    if (this.input) {
+      var groups = this.input.querySelectorAll("optgroup");
+      for (var i = 0; i < groups.length; i++) groups[i].hidden = false;
+    }
+  }
+
+  /**
+   * Hide an optgroup when every option under it is hidden, show it
+   * otherwise. No-op if `parent` isn't an <optgroup>.
+   * @private
+   */
+  _updateOptgroupVisibility(parent) {
+    if (!parent || parent.tagName !== "OPTGROUP") return;
+    var hasVisible = parent.querySelector("option:not([hidden])") !== null;
+    parent.hidden = !hasVisible;
   }
 
   /**
@@ -1333,8 +1439,43 @@ class ZFormField {
    * @returns {void}
    */
   feedData(food, clear = true) {
-    if (this.type != "select") {
+    if (this.type != "select" && this.type != "multi-select") {
       console.warn("Do not feed select data to non select input!");
+    }
+
+    if (this.type == "multi-select") {
+      if (clear) {
+        this.input.innerHTML = "";
+        this.input.appendChild(this.placeholderOption);
+        this.foodMap = {};
+        this.optionMap = {};
+        this.clearSelectedValues();
+      }
+
+      var currentOptgroup = null;
+      for (var data of food) {
+        if (data.type == "optgroup") {
+          currentOptgroup = document.createElement("optgroup");
+          currentOptgroup.setAttribute("label", data.text);
+          this.input.appendChild(currentOptgroup);
+          continue;
+        }
+
+        var value = data.value ?? data.text;
+        var text = data.text ?? data.value;
+        this.foodMap[value] = text;
+
+        var option = document.createElement("option");
+        option.innerHTML = text;
+        option.setAttribute("value", value);
+        (currentOptgroup || this.input).appendChild(option);
+        this.optionMap[value] = option;
+      }
+
+      if (this.options.value !== undefined) {
+        this.value = this.options.value;
+      }
+      return;
     }
 
     if (clear) {
@@ -1364,7 +1505,7 @@ class ZFormField {
     }
 
     if(this.optgroup != null) this.input.appendChild(this.optgroup);
-    
+
     if (this.options.value !== undefined) {
       this.value = this.options.value;
     }
@@ -1375,11 +1516,28 @@ class ZFormField {
    * @returns {string} The data containing string
    */
   getPostString() {
+    if (this.type == "multi-select") {
+      if (this.value.length === 0) return "";
+      // PHP-native array form: name[]=v1&name[]=v2 -> $_POST[name] is an
+      // actual array. Empty selection is omitted entirely so isset() in
+      // the server-side required rule catches it.
+      var parts = [];
+      for (var v of this.value) {
+        parts.push(this.name + "[]=<#decURI#>" + encodeURIComponent(v));
+      }
+      return parts.join("&");
+    }
     return this.name + "=<#decURI#>" + encodeURIComponent(this.value);
   }
 
   /**
    * Appends data to a form data object. This form data object can then be used to send the form with multipart/form-data
+   *
+   * Multi-selects emit one `name[]=value` entry per selected item so PHP
+   * parses `$_POST[name]` as a real array. An empty multi-select is
+   * *omitted* from the FormData entirely — `isset($_POST[$name])` is
+   * false, so the existing server-side `->required()` rule catches it.
+   *
    * @param {FormData} data An existing FormData object to append to
    * @returns {void}
    */
@@ -1387,6 +1545,11 @@ class ZFormField {
     if (this.type == "file") {
       if (this.input.files[0]) {
         data.append(this.name, this.input.files[0], this.value);
+      }
+    } else if (this.type == "multi-select") {
+      if (this.value.length === 0) return;
+      for (var v of this.value) {
+        data.append(this.name + "[]", "<#decURI#>" + encodeURIComponent(v));
       }
     } else {
       data.set(this.name, "<#decURI#>" + encodeURIComponent(this.value));
@@ -1399,6 +1562,10 @@ class ZFormField {
    * Options for selects and auto completes will persist.
    */
   reset() {
+    if (this.type == "multi-select") {
+      this.value = this.default ?? [];
+      return;
+    }
     this.input.value = this.default ?? "";
   }
 }

--- a/web/Z.js
+++ b/web/Z.js
@@ -111,6 +111,7 @@ Z = {
     error_range: "The number is too large to too small. It must be between [0] and [1].",
     error_unique: "This already exists!",
     error_exist: "This does not exist!",
+    error_in: "This value is not in the allowed list!",
     error_integer: "This is not an integer!",
     error_date: "Please give a correct date!",
     error_regex: "The input does not meet the required pattern!",


### PR DESCRIPTION
## Summary

Adds a first-class `multi-select` form field type to `Z.js` plus the framework-side plumbing for it to feel native — array-aware validation rules, JSON auto-encode on insert, and a new `->in()` allow-list rule. Submissions arrive as real PHP arrays (`name[]=v1&name[]=v2`), so user code is just `$req->getPost("skills")` — no `json_decode`, no manual encoding, no `noSave` hacks.

## Highlights

- **New `multi-select` type in Z.js** — picker `<select>` + removable badges. Selected options are hidden from the dropdown until unselected. Honors `food`, `placeholder`, `default`, `value`, `required`, and optgroups. `field.value` returns a real JS array; assigning an array repopulates the badges. Empty selections are omitted from the POST (checkbox semantics), so the server-side `->required()` rule catches them via `isset()` without any special-casing. Compatible with PR #143's planned `field.disable()` via a `typeof this.isDisabled === "function"` guard on badge clicks.
- **`insertDatabase` / `updateDatabase` auto-encode array values as JSON** — mysqli `bind_param` can't bind a PHP array; the framework now `json_encode`s array values at bind time. Two lines per method, scalar values unaffected. A JSON, TEXT, or VARCHAR column all work as targets.
- **Array-aware existing rules** — `->length($min, $max)` measures item count for arrays; `->regex()` and `->exists("table", "field")` run per item and fail as soon as any item fails. Scalar fields behave exactly as before. PHPDoc on `filter`/`unique`/`integer`/`range`/`date` calls out that they remain scalar-only.
- **New `->in($allowedValues)` rule** — in-memory allow-list check. Works for both plain `select` (single value) and `multi-select` (per item). Guards against tampered POST payloads where the client sends an option that wasn't in the rendered dropdown.

## API in one snippet

```php
$formResult = $req->validateForm([
    (new FormField("skills", "skills_json"))
        ->required()
        ->length(1, 5)
        ->in($availableSkillIds),
]);

if ($formResult->hasErrors) {
    return $res->formErrors($formResult->errors);
}

$res->insertDatabase("project", $formResult);   // stores ["1","4"] in skills_json
```

```js
form.createField({
    name: "skills",
    type: "multi-select",
    food: <?= $opt["skills"] ?>,
    value: <?= json_encode($opt["project"]["skills"] ?? []) ?>,
    required: true,
});
```

## Commits

5 atomic, conventional-commit messages:

1. `feat(forms): add multi-select field type with native array submission` — Z.js feature, Response.php JSON auto-encode, migration JSON column.
2. `feat(forms): make length, regex, exists validation rules array-aware` — per-item iteration; PHPDoc updates.
3. `feat(forms): add in() validation rule for allow-list checks` — new rule, validator branch, `error_in` lang string.
4. `test(forms): cover multi-select and array-aware validation rules` — 49 cypress cases across `multi-select.cy.js` (37) and `list-rules.cy.js` (12), plus fixture controllers and views.
5. `docs(forms): document multi-select and array-aware validation rules` — new "Multi Select" section and new "Rules on array values" subsection in `auto-form-validation.md`.

## Test plan

- [x] `tests/cypress/e2e/form/multi-select.cy.js` — 37 cases: render, display behavior, selection management, value getter/setter, submission, required, placeholder, default, optgroups, disabled-lock, pre-loaded values.
- [x] `tests/cypress/e2e/form/list-rules.cy.js` — 12 cases: `length` count, `regex` per-item, `in()` on multi-select and plain select (pass/fail/mixed), `exists()` per-item DB check (pass/fail/mixed).
- [x] Full e2e suite (606 tests) — no regressions: prior run all green except 3 pre-existing skipped specs.
- [x] PHP syntax check on `Field.php`, `CanValidateForm.php`, `Response.php`, fixture controllers.
- [x] JS syntax check on `web/Z.js`.

## PR #143 compatibility

Designed to merge cleanly alongside the open form-ergonomics PR. The badge-click handler uses `typeof this.isDisabled === "function"` so once #143 lands and adds `field.disable()`, the multi-select honors it without any further changes.