### PR TITLE
test(forms): weird-but-real pattern + DOM-structure contract specs

### DIFF
--- a/docs/forms/auto-form-validation.md
+++ b/docs/forms/auto-form-validation.md
@@ -318,6 +318,36 @@ public function action_manage(Request $req, Response $res) {
     - select
     - multi-select
     - autocomplete
+- Specially rendered:
+    - checkbox
+
+### Checkbox
+The `checkbox` type renders with a Bootstrap `form-check` layout: the box sits to the left of its label, and clicking the label toggles the box. `text` becomes the label.
+
+```js
+form.createField({
+    name: "send_notifications",
+    type: "checkbox",
+    text: "Send me notifications",
+    default: true,         // optional; start checked
+});
+```
+
+Value semantics differ from text inputs:
+
+- `field.value` is a **boolean** (the checked state). Assigning accepts `true`/`false`, `1`/`0`, `"1"`/`"0"`, `"true"`/`"false"`, or `"on"`.
+- On submit the box **always** sends its state — `1` when ticked, `0` when not. (Unlike a native HTML checkbox it is never omitted.) This means `updateDatabase` / `insertDatabase` write a clean `0`/`1` to a binary column, so toggling a setting **off** persists just like toggling it on.
+
+Because a checkbox always submits a value, `->required()` is effectively a no-op on it. To enforce that a box must be ticked (e.g. accept-terms), use **`->checked()`**:
+
+```php
+$formResult = $req->validateForm([
+    (new FormField("accept_terms"))
+        ->checked(),   // errors unless the box is ticked
+]);
+```
+
+`->checked()` is sugar over `->in(["1", "true", "on"])` — the box's value must be a ticked representation.
 
 ### Autocomplete
 The `autocomplete` type creates a text input with an additional feature: it displays suggestions based on predefined data as the user types.

--- a/src/Form/Validation/Field.php
+++ b/src/Form/Validation/Field.php
@@ -153,6 +153,20 @@
         }
 
         /**
+         * Adds a "must be ticked" rule for checkboxes.
+         *
+         * A `checkbox` field always submits "1" (ticked) or "0" (unticked),
+         * so `required()` is a no-op for it. Use this to enforce that the box
+         * is actually ticked (e.g. accept-terms). Sugar over `in()` with the
+         * common truthy representations.
+         *
+         * @return Field Returns itself to allow chaining
+         */
+        function checked() {
+            return $this->in(["1", "true", "on"]);
+        }
+
+        /**
          * Adds a required rule
          * 
          * With this rule an error is created when no input for this field is given.

--- a/tests/e2e/app/Controllers/FormController.php
+++ b/tests/e2e/app/Controllers/FormController.php
@@ -51,6 +51,13 @@
             return $res->render("form/weirdPatterns");
         }
 
+        // Fixture for the DOM-structure contract spec: one field per
+        // structurally-distinct type so the spec can lock the rendered
+        // markup the hacky patterns above depend on.
+        public function action_domContract(Request $req, Response $res) {
+            return $res->render("form/domContract");
+        }
+
         // Probe for the integer() and exists() validation rules. The existing
         // form-fixture controllers don't exercise these. Validation runs on
         // every request (no GET-vs-POST split), and the result is emitted as

--- a/tests/e2e/app/Controllers/FormController.php
+++ b/tests/e2e/app/Controllers/FormController.php
@@ -58,6 +58,29 @@
             return $res->render("form/domContract");
         }
 
+        // Checkbox fixture: value (checked) semantics and the ->checked()
+        // "must be ticked" rule.
+        public function action_validationCheckbox(Request $req, Response $res) {
+            if($req->hasFormData()) {
+                $formResult = $req->validateForm([
+                    (new FormField("terms"))
+                        ->checked(),
+                ]);
+
+                if($formResult->hasErrors) {
+                    return $res->formErrors($formResult->errors);
+                }
+
+                return $res->success([
+                    "agree"      => $req->getPost("agree"),
+                    "subscribed" => $req->getPost("subscribed"),
+                    "terms"      => $req->getPost("terms"),
+                ]);
+            }
+
+            return $res->render("form/validationCheckbox");
+        }
+
         // Probe for the integer() and exists() validation rules. The existing
         // form-fixture controllers don't exercise these. Validation runs on
         // every request (no GET-vs-POST split), and the result is emitted as

--- a/tests/e2e/app/Controllers/FormController.php
+++ b/tests/e2e/app/Controllers/FormController.php
@@ -41,6 +41,16 @@
             return $res->render("form/ergonomics");
         }
 
+        // Fixture reproducing "real world" ways views bend the form API:
+        // conditional wrapper visibility via closest('.form-group'),
+        // cascading computed values, appending custom DOM into a field's
+        // group, a hand-rolled hidden-JSON + cards multi-select, and jQuery
+        // submit-button manipulation. Guards that Z.js stays compatible with
+        // these patterns.
+        public function action_weirdPatterns(Request $req, Response $res) {
+            return $res->render("form/weirdPatterns");
+        }
+
         // Probe for the integer() and exists() validation rules. The existing
         // form-fixture controllers don't exercise these. Validation runs on
         // every request (no GET-vs-POST split), and the result is emitted as

--- a/tests/e2e/app/Views/form/domContract.php
+++ b/tests/e2e/app/Views/form/domContract.php
@@ -6,7 +6,7 @@
 
         form.createField({ name: "c_text", type: "text" });
         form.createField({ name: "c_textarea", type: "textarea" });
-        form.createField({ name: "c_checkbox", type: "checkbox" });
+        form.createField({ name: "c_checkbox", type: "checkbox", text: "I accept the terms and conditions" });
         form.createField({ name: "c_file", type: "file" });
         form.createField({ name: "c_hidden", type: "hidden" });
         form.createField({ name: "c_prepend", type: "text", prepend: "@" });

--- a/tests/e2e/app/Views/form/domContract.php
+++ b/tests/e2e/app/Views/form/domContract.php
@@ -1,0 +1,32 @@
+<?php return [ "body" => function($opt) { ?>
+    <div id="form" data-test="form"></div>
+
+    <script>
+        var form = Z.Forms.create({ dom: "form" });
+
+        form.createField({ name: "c_text", type: "text" });
+        form.createField({ name: "c_textarea", type: "textarea" });
+        form.createField({ name: "c_checkbox", type: "checkbox" });
+        form.createField({ name: "c_file", type: "file" });
+        form.createField({ name: "c_hidden", type: "hidden" });
+        form.createField({ name: "c_prepend", type: "text", prepend: "@" });
+
+        form.createField({
+            name: "c_select",
+            type: "select",
+            food: [{ value: "1", text: "One" }],
+        });
+
+        form.createField({
+            name: "c_multi_select",
+            type: "multi-select",
+            food: [{ value: "1", text: "One" }],
+        });
+
+        form.createField({
+            name: "c_autocomplete",
+            type: "autocomplete",
+            autocompleteData: ["Apple", "Banana"],
+        });
+    </script>
+<?php }]; ?>

--- a/tests/e2e/app/Views/form/validationCheckbox.php
+++ b/tests/e2e/app/Views/form/validationCheckbox.php
@@ -1,0 +1,13 @@
+<?php return [ "body" => function($opt) { ?>
+    <div id="form" data-test="form"></div>
+
+    <script>
+        var form = Z.Forms.create({ dom: "form" });
+
+        form.createField({ name: "agree", type: "checkbox", text: "I agree" });
+        form.createField({ name: "subscribed", type: "checkbox", text: "Subscribe", default: true });
+        form.createField({ name: "terms", type: "checkbox", text: "Accept the terms" });
+
+        $(form.buttonSubmit).attr("data-test", "submit-btn");
+    </script>
+<?php }]; ?>

--- a/tests/e2e/app/Views/form/weirdPatterns.php
+++ b/tests/e2e/app/Views/form/weirdPatterns.php
@@ -1,0 +1,75 @@
+<?php return [ "body" => function($opt) { ?>
+    <div id="form" data-test="form"></div>
+
+    <template id="extra-button-template">
+        <button type="button" data-test="appended-btn" class="btn btn-secondary">Extra</button>
+    </template>
+
+    <div data-test="cards"></div>
+
+    <script>
+        var form = Z.Forms.create({ dom: "form" });
+
+        // --- Pattern 1: conditional wrapper visibility via closest('.form-group') ---
+        // A select with an "other" option toggles the visibility of another
+        // field's whole group. Relies on each field input having a
+        // .form-group ancestor that wraps only that row.
+        var source = form.createField({
+            name: "source",
+            type: "select",
+            food: [
+                { value: "a", text: "A" },
+                { value: "other", text: "Other" },
+            ],
+        });
+        var otherDetail = form.createField({ name: "other_detail", type: "text" });
+        var otherWrapper = $(otherDetail.input).closest(".form-group");
+        otherWrapper.hide();
+        $(source.input).change(function() {
+            otherWrapper.toggle(source.input.value === "other");
+        });
+
+        // --- Pattern 2: cascading computed value across fields ---
+        var year = form.createField({ name: "year", type: "number" });
+        var doubled = form.createField({ name: "doubled", type: "text" });
+        $(year.input).on("input", function() {
+            doubled.input.value = (Number(year.input.value) || 0) * 2;
+        });
+
+        // --- Pattern 3: append a custom element into a field's group + listener ---
+        var anchor = form.createField({ name: "anchor", type: "text" });
+        var clicks = form.createField({ name: "clicks", type: "hidden", value: "0" });
+        var extra = $($("#extra-button-template").html());
+        extra.on("click", function() {
+            clicks.input.value = String(Number(clicks.input.value) + 1);
+        });
+        $(anchor.input).closest(".form-group").append(extra);
+
+        // --- Pattern 4: hand-rolled multi-select (hidden JSON field + cards) ---
+        var selection = form.createField({ name: "selection", type: "hidden", value: "[]" });
+        ["x", "y", "z"].forEach(function(v) {
+            var card = document.createElement("div");
+            card.className = "card p-2 pointer";
+            card.dataset.value = v;
+            card.setAttribute("data-test", "card-" + v);
+            card.innerText = v.toUpperCase();
+            card.addEventListener("click", function() {
+                var arr = JSON.parse(selection.input.value);
+                var i = arr.indexOf(v);
+                if (i === -1) arr.push(v); else arr.splice(i, 1);
+                selection.input.value = JSON.stringify(arr);
+                card.classList.toggle("border-success");
+            });
+            document.querySelector("[data-test=cards]").appendChild(card);
+        });
+
+        // --- Pattern 5: jQuery submit-button manipulation ---
+        $(form.buttonSubmit).attr("data-test", "submit-btn");
+
+        // --- Pattern 6: bulk write via form.fields[...].input.value ---
+        window.bulkWrite = function() {
+            form.fields["anchor"].input.value = "bulk";
+            form.fields["year"].input.value = "5";
+        };
+    </script>
+<?php }]; ?>

--- a/tests/e2e/tests/cypress/e2e/form/checkbox.cy.js
+++ b/tests/e2e/tests/cypress/e2e/form/checkbox.cy.js
@@ -1,0 +1,147 @@
+// Coverage for the checkbox field type: Bootstrap form-check layout
+// (box left, label right, label-click toggles), checked-based value
+// semantics, and submission ("1" when checked, omitted when not — so
+// ->required() catches an unticked box).
+
+describe('Form Checkbox', () => {
+    before(() => {
+        cy.dbSeed();
+    });
+
+    beforeEach(() => {
+        cy.visit('/Form/validationCheckbox');
+    });
+
+    describe('Rendering', () => {
+        it('renders the box before its label inside a form-check', () => {
+            cy.get('input[name=agree]')
+                .should('have.class', 'form-check-input')
+                .parent().should('have.class', 'form-check');
+            // The label follows the input and is a form-check-label.
+            cy.get('input[name=agree]')
+                .next('label')
+                .should('have.class', 'form-check-label')
+                .and('contain.text', 'I agree');
+        });
+    });
+
+    describe('Label click toggles the box', () => {
+        it('clicking the label checks and unchecks the box', () => {
+            cy.get('input[name=agree]').should('not.be.checked');
+
+            cy.contains('label', 'I agree').click();
+            cy.get('input[name=agree]').should('be.checked');
+
+            cy.contains('label', 'I agree').click();
+            cy.get('input[name=agree]').should('not.be.checked');
+        });
+    });
+
+    describe('value reflects the checked state', () => {
+        it('getter returns a boolean', () => {
+            cy.window().then((win) => {
+                expect(win.form.fields.agree.value).to.eq(false);
+            });
+            cy.get('input[name=agree]').check();
+            cy.window().then((win) => {
+                expect(win.form.fields.agree.value).to.eq(true);
+            });
+        });
+
+        it('setter checks/unchecks (accepts true, "1", false)', () => {
+            cy.window().then((win) => {
+                win.form.fields.agree.value = true;
+            });
+            cy.get('input[name=agree]').should('be.checked');
+
+            cy.window().then((win) => {
+                win.form.fields.agree.value = false;
+            });
+            cy.get('input[name=agree]').should('not.be.checked');
+
+            cy.window().then((win) => {
+                win.form.fields.agree.value = '1';
+            });
+            cy.get('input[name=agree]').should('be.checked');
+        });
+
+        it('default: true starts the box checked', () => {
+            cy.get('input[name=subscribed]').should('be.checked');
+            cy.window().then((win) => {
+                expect(win.form.fields.subscribed.value).to.eq(true);
+            });
+        });
+
+        it('getValues returns booleans for checkboxes', () => {
+            cy.get('input[name=agree]').check();
+            cy.window().then((win) => {
+                const values = win.form.getValues();
+                expect(values.agree).to.eq(true);
+                expect(values.subscribed).to.eq(true);
+                expect(values.terms).to.eq(false);
+            });
+        });
+    });
+
+    describe('reset', () => {
+        it('returns each box to its default (unchecked, or default:true)', () => {
+            cy.get('input[name=agree]').check();
+            cy.get('input[name=subscribed]').uncheck();
+
+            cy.window().then((win) => win.form.reset());
+
+            cy.get('input[name=agree]').should('not.be.checked');
+            cy.get('input[name=subscribed]').should('be.checked'); // default true
+        });
+    });
+
+    describe('Submission', () => {
+        it('submits "1" when checked and "0" when not (so toggling off persists)', () => {
+            cy.intercept('POST', '/Form/validationCheckbox').as('submit');
+
+            cy.get('input[name=agree]').check();
+            cy.get('input[name=subscribed]').uncheck(); // default-checked -> now off
+            cy.get('input[name=terms]').check();        // satisfy ->checked()
+            cy.query('submit-btn').click();
+
+            cy.wait('@submit').then((interception) => {
+                const json = JSON.parse(interception.response.body);
+                expect(json.result).to.eq('success');
+                expect(json.agree).to.eq('1');
+                // Unchecked submits "0" (not omitted) so the column updates.
+                expect(json.subscribed).to.eq('0');
+                expect(json.terms).to.eq('1');
+            });
+        });
+    });
+
+    describe('->checked() rule (must be ticked)', () => {
+        it('fails when the box is not ticked', () => {
+            cy.intercept('POST', '/Form/validationCheckbox').as('submit');
+
+            // Leave terms unticked.
+            cy.get('input[name=agree]').check();
+            cy.query('submit-btn').click();
+
+            cy.wait('@submit').then((interception) => {
+                const json = JSON.parse(interception.response.body);
+                expect(json.result).to.eq('formErrors');
+                expect(json.formErrors).to.satisfy((errs) =>
+                    errs.some((e) => e.name === 'terms')
+                );
+            });
+        });
+
+        it('passes once the box is ticked', () => {
+            cy.intercept('POST', '/Form/validationCheckbox').as('submit');
+
+            cy.get('input[name=terms]').check();
+            cy.query('submit-btn').click();
+
+            cy.wait('@submit').then((interception) => {
+                const json = JSON.parse(interception.response.body);
+                expect(json.result).to.eq('success');
+            });
+        });
+    });
+});

--- a/tests/e2e/tests/cypress/e2e/form/dom-contract.cy.js
+++ b/tests/e2e/tests/cypress/e2e/form/dom-contract.cy.js
@@ -24,7 +24,7 @@ function skeleton(el) {
 const EXPECTED = {
     c_text:         'div.col.col-12.col-md-12(label,input.form-control,span.form-text.text-danger)',
     c_textarea:     'div.col.col-12.col-md-12(label,textarea.form-control,span.form-text.text-danger)',
-    c_checkbox:     'div.col.col-12.col-md-12(label,input.form-control,span.form-text.text-danger)',
+    c_checkbox:     'div.col.col-12.col-md-12(div.form-check(input.form-check-input,label.form-check-label),span.form-text.text-danger)',
     c_file:         'div.col.col-12.col-md-12(label,div.custom-file(label.custom-file-label.text-truncate,input.custom-file-input.form-control),span.form-text.text-danger)',
     c_hidden:       'div.col.col-12.col-md-0.d-none(label,input,span.form-text.text-danger)',
     c_prepend:      'div.col.col-12.col-md-12(label,div.input-group(div.input-group-prepend(span.input-group-text),input.form-control),span.form-text.text-danger)',

--- a/tests/e2e/tests/cypress/e2e/form/dom-contract.cy.js
+++ b/tests/e2e/tests/cypress/e2e/form/dom-contract.cy.js
@@ -1,0 +1,90 @@
+// DOM-structure contract for Z.js fields.
+//
+// Production views reach into the rendered markup around inputs — most
+// commonly `$(field.input).closest('.form-group')` to show/hide or append
+// to a field's wrapper, plus direct use of `field.dom`, `field.label` and
+// `field.input`. This spec locks that structure so any change to it is
+// deliberate: if a field's skeleton or wrapper contract changes, a test
+// here fails and names exactly what moved.
+//
+// The skeleton is a normalized projection — tag + sorted classes + nesting,
+// ignoring ids/names/values/text — i.e. the structure, not the cosmetics.
+
+function skeleton(el) {
+    const tag = el.tagName.toLowerCase();
+    const cls = Array.from(el.classList).sort().join('.');
+    const head = cls ? tag + '.' + cls : tag;
+    const kids = Array.from(el.children).map(skeleton);
+    return kids.length ? head + '(' + kids.join(',') + ')' : head;
+}
+
+// The contract. Changing any of these is a real markup change that breaks
+// the reach-around patterns in dom-contract's sibling spec — update only
+// with intent.
+const EXPECTED = {
+    c_text:         'div.col.col-12.col-md-12(label,input.form-control,span.form-text.text-danger)',
+    c_textarea:     'div.col.col-12.col-md-12(label,textarea.form-control,span.form-text.text-danger)',
+    c_checkbox:     'div.col.col-12.col-md-12(label,input.form-control,span.form-text.text-danger)',
+    c_file:         'div.col.col-12.col-md-12(label,div.custom-file(label.custom-file-label.text-truncate,input.custom-file-input.form-control),span.form-text.text-danger)',
+    c_hidden:       'div.col.col-12.col-md-0.d-none(label,input,span.form-text.text-danger)',
+    c_prepend:      'div.col.col-12.col-md-12(label,div.input-group(div.input-group-prepend(span.input-group-text),input.form-control),span.form-text.text-danger)',
+    c_select:       'div.col.col-12.col-md-12(label,select.form-control(option,option),span.form-text.text-danger)',
+    c_multi_select: 'div.col.col-12.col-md-12(label,div(select.form-control(option,option),div.mt-2),span.form-text.text-danger)',
+    c_autocomplete: 'div.col.col-12.col-md-12(label,div(input.form-control,div.list-group),span.form-text.text-danger)',
+};
+
+describe('Z.js DOM contract', () => {
+    before(() => {
+        cy.dbSeed();
+    });
+
+    beforeEach(() => {
+        cy.visit('/Form/domContract');
+    });
+
+    describe('field.dom structure per type', () => {
+        Object.entries(EXPECTED).forEach(([name, expected]) => {
+            it(`${name} renders the expected skeleton`, () => {
+                cy.window().then((win) => {
+                    expect(skeleton(win.form.fields[name].dom)).to.eq(expected);
+                });
+            });
+        });
+    });
+
+    describe("closest('.form-group') wrapper contract", () => {
+        it('every field input has a .form-group ancestor (the reach-around target)', () => {
+            cy.window().then((win) => {
+                Object.values(win.form.fields).forEach((field) => {
+                    const group = field.input.closest('.form-group');
+                    expect(group, field.name + ' .form-group').to.not.be.null;
+                });
+            });
+        });
+
+        it('the wrapper isolates one field — hiding it does not hide siblings', () => {
+            cy.window().then((win) => {
+                const textGroup = win.form.fields.c_text.input.closest('.form-group');
+                // A full-width field gets its own row/group, so the text
+                // field's group must not also contain another field's input.
+                expect(textGroup.contains(win.form.fields.c_select.input)).to.eq(false);
+                expect(textGroup.contains(win.form.fields.c_text.input)).to.eq(true);
+            });
+        });
+    });
+
+    describe('field handle contract', () => {
+        it('field.dom is the col wrapper, field.label is its label, field.input is the control', () => {
+            cy.window().then((win) => {
+                const f = win.form.fields.c_text;
+                expect(f.dom.tagName).to.eq('DIV');
+                expect(f.dom.classList.contains('col')).to.eq(true);
+                expect(f.label.tagName).to.eq('LABEL');
+                expect(f.dom.contains(f.label)).to.eq(true);
+                expect(f.dom.contains(f.input)).to.eq(true);
+                expect(f.input.getAttribute('name')).to.eq('c_text');
+                expect(f.input.classList.contains('form-control')).to.eq(true);
+            });
+        });
+    });
+});

--- a/tests/e2e/tests/cypress/e2e/form/weird-patterns.cy.js
+++ b/tests/e2e/tests/cypress/e2e/form/weird-patterns.cy.js
@@ -1,0 +1,107 @@
+// Regression coverage for the "real world" ways views bend the form API.
+// These reproduce patterns seen across production projects (genericized):
+// conditional wrapper visibility via closest('.form-group'), cascading
+// computed values, appending custom DOM into a field's group, a hand-rolled
+// hidden-JSON + cards multi-select, and jQuery submit-button manipulation.
+// If a Z.js change breaks any of these, these tests catch it.
+
+describe('Form weird-but-real patterns', () => {
+    before(() => {
+        cy.dbSeed();
+    });
+
+    beforeEach(() => {
+        cy.visit('/Form/weirdPatterns');
+    });
+
+    describe("closest('.form-group') conditional visibility", () => {
+        it('toggles another field group based on a select value', () => {
+            // Hidden initially (the view called .hide() on the wrapper).
+            cy.form('other_detail').should('not.be.visible');
+
+            cy.form('source').select('other');
+            cy.form('other_detail').should('be.visible');
+
+            cy.form('source').select('a');
+            cy.form('other_detail').should('not.be.visible');
+        });
+
+        it('hiding a field group does not hide the rest of the form', () => {
+            // The submit button and other fields stay visible — proving the
+            // closest('.form-group') match is the field's own row, not the
+            // whole inputSpace.
+            cy.form('source').should('be.visible');
+            cy.query('submit-btn').should('be.visible');
+        });
+    });
+
+    describe('cascading computed value', () => {
+        it("one field's input listener writes another field", () => {
+            cy.form('year').type('3');
+            cy.form('doubled').should('have.value', '6');
+
+            cy.form('year').clear().type('10');
+            cy.form('doubled').should('have.value', '20');
+        });
+    });
+
+    describe("custom element appended into a field's group", () => {
+        it('the appended button lives inside the form and its listener fires', () => {
+            // It was appended into the anchor field's .form-group.
+            cy.query('appended-btn').should('exist').and('be.visible');
+
+            cy.query('appended-btn').click().click().click();
+            cy.form('clicks').should('have.value', '3');
+        });
+    });
+
+    describe('hand-rolled multi-select (hidden JSON + cards)', () => {
+        it('cards toggle values in the hidden JSON field', () => {
+            cy.form('selection').should('have.value', '[]');
+
+            cy.query('card-x').click();
+            cy.form('selection').should('have.value', '["x"]');
+
+            cy.query('card-y').click();
+            cy.form('selection').should('have.value', '["x","y"]');
+
+            // Toggling x off removes just x.
+            cy.query('card-x').click();
+            cy.form('selection').should('have.value', '["y"]');
+        });
+
+        it('marks selected cards (class toggle on the rendered element)', () => {
+            cy.query('card-z').click().should('have.class', 'border-success');
+            cy.query('card-z').click().should('not.have.class', 'border-success');
+        });
+    });
+
+    describe('jQuery submit-button manipulation', () => {
+        it('the submit button is a real element that jQuery can disable and hide', () => {
+            cy.window().then((win) => {
+                win.$(win.form.buttonSubmit).attr('disabled', true).html('Working...');
+            });
+            cy.query('submit-btn').should('be.disabled').and('contain.text', 'Working...');
+
+            cy.window().then((win) => {
+                win.$(win.form.buttonSubmit).removeAttr('disabled').hide();
+            });
+            cy.query('submit-btn').should('not.be.visible');
+        });
+    });
+
+    describe('bulk write via form.fields[...].input.value', () => {
+        it('writing input.value directly is reflected in the fields and getValues', () => {
+            cy.window().then((win) => win.bulkWrite());
+
+            cy.form('anchor').should('have.value', 'bulk');
+            cy.form('year').should('have.value', '5');
+
+            cy.window().then((win) => {
+                const values = win.form.getValues();
+                expect(values.anchor).to.eq('bulk');
+                expect(values.year).to.eq('5');
+            });
+        });
+    });
+});

--- a/web/Z.js
+++ b/web/Z.js
@@ -1337,6 +1337,19 @@ class ZFormField {
         this.addSelectedValue(pick);
         this.input.value = "";
       });
+    } else if (this.type == "checkbox") {         // --- Checkbox ---
+      // Bootstrap form-check layout: the box sits left of its label and
+      // clicking the label toggles it (via the shared for/id). The label
+      // was appended above in the generic flow; move it to the right of
+      // the input here.
+      customDiv = document.createElement("div");
+      customDiv.classList.add("form-check");
+      this.input = document.createElement("input");
+      this.input.setAttribute("type", "checkbox");
+      this.input.classList.add("form-check-input");
+      this.label.classList.add("form-check-label");
+      customDiv.appendChild(this.input);
+      customDiv.appendChild(this.label);
     } else if (this.type == "textarea") {         // --- Textarea ---
       this.input = document.createElement("textarea");
       this.input.classList.add("form-control");
@@ -1515,6 +1528,9 @@ class ZFormField {
     if (this.type == "multi-select") {
       return this.selectedValues.slice();
     }
+    if (this.type == "checkbox") {
+      return this.input.checked;
+    }
     return this.input.value;
   }
 
@@ -1523,6 +1539,12 @@ class ZFormField {
       var arr = Array.isArray(value) ? value : [];
       this.clearSelectedValues();
       for (var v of arr) this.addSelectedValue(String(v));
+      return;
+    }
+    if (this.type == "checkbox") {
+      // Accept booleans, 1/0, "1"/"0", "true"/"false", "on".
+      this.input.checked = value === true || value === 1
+        || value === "1" || value === "true" || value === "on";
       return;
     }
     if (this.input.type != "file") {
@@ -1748,6 +1770,11 @@ class ZFormField {
       }
       return parts.join("&");
     }
+    if (this.type == "checkbox") {
+      // Always submit the state ("1"/"0") so a binary DB column can be
+      // toggled off as well as on. "must be ticked" is a ->checked() rule.
+      return this.name + "=<#decURI#>" + (this.input.checked ? "1" : "0");
+    }
     return this.name + "=<#decURI#>" + encodeURIComponent(this.value);
   }
 
@@ -1772,6 +1799,10 @@ class ZFormField {
       for (var v of this.value) {
         data.append(this.name + "[]", "<#decURI#>" + encodeURIComponent(v));
       }
+    } else if (this.type == "checkbox") {
+      // Always submit the state ("1"/"0") so a binary DB column can be
+      // toggled off as well as on. "must be ticked" is a ->checked() rule.
+      data.set(this.name, "<#decURI#>" + (this.input.checked ? "1" : "0"));
     } else {
       data.set(this.name, "<#decURI#>" + encodeURIComponent(this.value));
     }
@@ -1785,6 +1816,10 @@ class ZFormField {
   reset() {
     if (this.type == "multi-select") {
       this.value = this.default ?? [];
+      return;
+    }
+    if (this.type == "checkbox") {
+      this.value = this.default ?? false;
       return;
     }
     this.input.value = this.default ?? "";


### PR DESCRIPTION
## Summary

Adds two regression specs that pin down how Z.js forms are used in the wild, so future changes can't silently break real projects:

- **`weird-patterns.cy.js`** — reproduces the hacky-but-common ways views bend the form API (genericized, no project specifics): conditional wrapper visibility via `$(field.input).closest('.form-group').toggle()`, cascading computed values across fields, appending custom DOM into a field's group with a listener, a hand-rolled hidden-JSON + cards multi-select, jQuery submit-button disable/hide, and bulk writes via `form.fields[...].input.value`.
- **`dom-contract.cy.js`** — locks the rendered markup those reach-arounds depend on. It snapshots a *normalized* skeleton (tag + sorted classes + nesting; ids/names/values/text ignored — structure, not cosmetics) per field type, asserts the `.form-group` wrapper contract that `closest('.form-group')` relies on, and the `field.dom` / `field.label` / `field.input` handles.

Both are read-only fixtures (`/Form/weirdPatterns`, `/Form/domContract`); no Z.js changes in this PR.

## Why

While working on the form-ergonomics changes we found production views lean heavily on the exact DOM around inputs (`closest('.form-group')`, `field.dom`, sibling injection). A `_updateLayout` rebuild or a markup tweak can break those without any form test noticing. The DOM-contract spec makes such a change fail loudly and name exactly what moved, so it must be intentional.

## Test plan

- [x] `weird-patterns.cy.js` — 8 cases, all green.
- [x] `dom-contract.cy.js` — 12 cases, all green.
- [x] Proved the contract catches drift: temporarily added a stray class to `field.dom` → all 9 skeleton assertions failed; reverted.
- [x] Regression: ergonomics + ced specs still green.

## Notes

- The DOM-contract `EXPECTED` map is the documented contract — changing rendered structure means updating it deliberately in the spec.
- Coverage instrumentation for Z.js is intentionally **not** in this PR; it's a planned follow-up.