### PR TITLE
feat(auth): native Argon2id password hashing with rehash-on-login

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ For Git workflow and commit conventions, see **[docs/contributing/how-to-contrib
 # Bring up the dockerized e2e stack
 cd tests/e2e && npm run start
 
-# Run the full e2e suite (~3 min, 300+ tests)
+# Run the full e2e suite (~6 min, 590+ tests)
 npm run tests
 
 # Run one spec

--- a/Changelog.md
+++ b/Changelog.md
@@ -27,4 +27,7 @@ These todos should be as temporary as possible:
 1. Added `Role::setPermissionsByRole(Role $role)` to replace a role's permissions with another role's permissions in one call (removes current, copies source).
 1. `User::add()` now accepts `null` for the `$password` parameter, allowing users to be created without a password (e.g. invite or SSO flows where the credential is set later via `updatePassword()`).
 1. Deprecate getZControllers in RequestResponseHandler
+1. Password hashing now uses native Argon2id and the `zubzet/password-hash-utilities` dependency has been removed. Existing hashes still verify through a legacy path and upgrade themselves to Argon2id on the next successful login. See the [Password Handling docs](docs/core-features/password-handling.md).
+1. Added `password_scheme` and `last_password_rehash_at` columns to `z_user`; existing password rows are marked `legacy`. **Migrator note:** the schema migration runs automatically. Optionally run `php index.php auth:migrate-hashing` to bring dormant legacy rows onto Argon2id before their next login.
+1. Added `User::verifyPassword()` (self-healing login check) plus the `Password` and `Verification` API for hashing and verifying outside a `User`. **Migrator note:** `z_loginModel::checkPassword()` is deprecated in favor of these; the existing 3-argument call still works.
 1. Deprecate `<#decb64#>`

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,6 @@
     },
     "require": {
         "php": ">=8.0 <8.6",
-        "zubzet/password-hash-utilities": "1.0.*",
         "cakephp/database": "^4.5",
         "nikic/fast-route": "^1.3",
         "phpmailer/phpmailer": "^6.7",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0198c89edcdfeaca0bd72795c271b73c",
+    "content-hash": "556464788056ae54929c52dbb05d3b3c",
     "packages": [
         {
             "name": "cakephp/core",
@@ -2616,45 +2616,6 @@
                 }
             ],
             "time": "2025-11-17T20:03:58+00:00"
-        },
-        {
-            "name": "zubzet/password-hash-utilities",
-            "version": "1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/zubzet/password-hash-utilities.git",
-                "reference": "eb0bdabf3cd8814a75327334afc9bb312749bde5"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/zubzet/password-hash-utilities/zipball/eb0bdabf3cd8814a75327334afc9bb312749bde5",
-                "reference": "eb0bdabf3cd8814a75327334afc9bb312749bde5",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.0"
-            },
-            "type": "li",
-            "autoload": {
-                "psr-4": {
-                    "ZubZet\\Utilities\\PasswordHash\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "GPL-3.0-or-later"
-            ],
-            "authors": [
-                {
-                    "name": "Alexander Zierhut",
-                    "email": "alex@zierhut-it.de"
-                }
-            ],
-            "support": {
-                "issues": "https://github.com/zubzet/password-hash-utilities/issues",
-                "source": "https://github.com/zubzet/password-hash-utilities/tree/1.0.0"
-            },
-            "time": "2022-04-17T20:50:04+00:00"
         }
     ],
     "packages-dev": [],

--- a/docs/contributing/agents/working-with-agents.md
+++ b/docs/contributing/agents/working-with-agents.md
@@ -17,7 +17,7 @@ There is no top-level `package.json` and no PHPUnit suite — testing is end-to-
 
 `src/` subdirectories at a glance:
 
-- `Authentication/` — `User`, `Session`, `Permission/`, role and group handling
+- `Authentication/` — `User`, `Session`, `Permission/`, `PasswordHash/` (native Argon2id, self-describing schemes, rehash-on-login), role and group handling
 - `Bootstrap/` — `Configuration` trait that parses `z_settings.ini`
 - `Core/` — Foundation traits (`CanRetrieveModel`, `CanRetrieveBooterSettings`, `Constants`, `FunctionConflictResolution`)
 - `Database/` — `Connection`, prepared-statement `Interaction`, migration commands
@@ -108,7 +108,7 @@ cd tests/e2e
 # Bring up the docker stack (~2 min first time)
 npm run start
 
-# Run the full suite headless (~3 min, 300+ tests)
+# Run the full suite headless (~6 min, 590+ tests)
 npm run tests
 
 # Run one spec

--- a/docs/core-features/password-handling.md
+++ b/docs/core-features/password-handling.md
@@ -1,0 +1,189 @@
+# Password Handling
+
+ZubZet hashes passwords with PHP's native **Argon2id**. The framework stores
+enough information alongside every hash to verify it, to recognise older hashes,
+and to upgrade them to the current algorithm automatically. Application code
+normally never touches a hash directly: the [`User`](permission-system.md) API
+covers creating users, setting passwords, and checking a login.
+
+## Where passwords are stored
+
+Credentials live on the `z_user` table:
+
+| Column | Purpose |
+| ------ | ------- |
+| `password` | The stored credential (an Argon2id hash for current accounts). |
+| `password_scheme` | Which format `password` is in: `native`, `legacy`, or `onion`. `NULL` for accounts without a password. |
+| `salt` | Per row salt for `legacy` and `onion` rows. `NULL` for `native`, because Argon2id embeds its own salt. |
+| `last_password_rehash_at` | When the stored hash was last produced. Useful for credential age policies. |
+
+There is no separate salt for native hashes. A native `password` value already
+contains the algorithm, the cost parameters, and a random salt in one
+self describing string, which is what makes transparent upgrades possible.
+
+## The three schemes
+
+The `password_scheme` column tells the verifier how to read a stored value, so
+the three formats can coexist while older accounts upgrade on their own.
+
+| Scheme | `password` holds | `salt` | Notes |
+| ------ | ---------------- | ------ | ----- |
+| `native` | An Argon2id hash from `password_hash()`. | `NULL` | The target format for every account. |
+| `legacy` | The hash produced by the framework's previous scheme. | set | Verify only. Upgraded to `native` on the next login. |
+| `onion` | A native Argon2id hash wrapping the legacy value. | set | A dormant account moved onto Argon2id ahead of its next login. Upgraded to `native` when the owner logs in. |
+
+## Adding users and setting passwords
+
+For building features and APIs, work through the `User` object. The plaintext is
+hashed for you, and the resulting account is always `native`.
+
+### Create a user with a password
+
+```php
+use ZubZet\Framework\Authentication\Permission\User;
+
+$user = User::add("person@example.com", "the-plaintext-password");
+```
+
+`User::add()` also accepts `null` for the password to create an account whose
+credential is set later (for example invite or single sign on flows):
+
+```php
+$user = User::add("person@example.com", null);
+// ... later ...
+$user->updatePassword("the-plaintext-password");
+```
+
+### Set or change a password
+
+```php
+$user->updatePassword("the-new-plaintext-password");
+```
+
+This writes a fresh `native` Argon2id hash, clears the salt, stamps
+`last_password_rehash_at`, and invalidates the user's existing sessions.
+
+### Check a password during login
+
+```php
+$user = User::byEmail($email);
+
+if ($user && $user->verifyPassword($plaintext)) {
+    // success
+}
+```
+
+`User::verifyPassword()` returns a boolean and is self healing: on a correct
+login it transparently upgrades a stale stored hash to a current `native` hash
+(see [Self healing upgrades](#self-healing-upgrades)). It is the password check
+used by the framework's own login flow.
+
+## The hash and verify API
+
+`User` is built on the lower level `ZubZet\Framework\Authentication\PasswordHash\Password`
+class, which you can use directly when you are not working with a `User` object.
+
+### Hashing
+
+```php
+use ZubZet\Framework\Authentication\PasswordHash\Password;
+
+$stored = Password::hash($plaintext); // Argon2id
+```
+
+`Password::hash()` rejects an empty or oversized input
+(`MIN_LENGTH_BYTES` to `MAX_LENGTH_BYTES`, the upper bound being a denial of
+service guard) by throwing an `InvalidArgumentException`.
+
+### Verifying
+
+```php
+$result = Password::verify($plaintext, $stored);
+
+if ($result->isCorrect()) {
+    // password matched
+}
+```
+
+`Password::verify()` returns a `Verification` value object rather than a bare
+boolean, so a single call can also report whether the stored hash should be
+refreshed:
+
+| Method | Returns |
+| ------ | ------- |
+| `isCorrect()` | Whether the password matched. |
+| `isUpgradeNeeded()` | Whether the stored hash is stale and should be replaced. |
+| `upgradePassword()` | The fresh `native` hash to persist. Guard with `isUpgradeNeeded()` first; calling it when no upgrade is pending throws a `LogicException`. |
+
+The hash inside `upgradePassword()` is computed only when you call it, so a
+plain `isCorrect()` check never pays for an upgrade it does not use.
+
+For `legacy` and `onion` values, pass the scheme and salt so the verifier knows
+how to read them:
+
+```php
+$result = Password::verify($plaintext, $stored, Password::LEGACY, $salt);
+```
+
+## Self healing upgrades
+
+ZubZet keeps stored hashes current without ever asking users to reset a working
+password. On a successful login, the stored hash is upgraded to a fresh
+`native` Argon2id hash when any of the following is true:
+
+- the account is still `legacy` or `onion`, or
+- the account is `native` but was hashed below the current cost.
+
+The second case relies on PHP's `password_needs_rehash()`. When you raise the
+Argon2id cost (see below), existing users are migrated one at a time as they log
+in, with no bulk operation and no forced reset.
+
+### Future proofing the work factor
+
+The work factor is PHP's Argon2id default cost. Hardware gets faster over time,
+so the recommended practice is to re measure every year or two and raise the
+cost when appropriate. Because the cost is embedded in each stored hash, raising
+it does not invalidate existing passwords: `password_needs_rehash()` simply
+reports the older hashes as stale, and the self healing path upgrades them on
+the next login.
+
+## Migrating an existing installation
+
+When you upgrade the framework, the schema migration runs automatically and
+marks every existing password row as `legacy`. Those accounts keep working
+unchanged and upgrade themselves to `native` on the next login.
+
+Rehash on login only reaches accounts that actually log in. To bring accounts
+that have not logged in yet onto Argon2id as well, run the onion migration once:
+
+```bash
+php index.php auth:migrate-hashing
+```
+
+This wraps every `legacy` hash in an Argon2id layer and marks the row `onion`,
+so the whole table moves onto the modern algorithm rather than only the active
+accounts. It is idempotent, so it is safe to run more than once, and the first
+successful login peels an `onion` row back to a single `native` hash.
+
+Wrapping an existing hash inside a stronger one is the same layered "onion"
+technique Facebook has publicly described for modernising its own password
+storage, which is where the name comes from.
+
+## A short history
+
+For years ZubZet hashed passwords with SHA-512 plus a per user salt and an
+additional transformation step, provided by a dedicated hashing library. That
+scheme served the framework reliably and shipped in production for a long time.
+
+Version 1.2.0 modernises password storage onto PHP's native Argon2id, the
+algorithm recommended by the current OWASP Password Storage guidance. Argon2id
+is memory hard and purpose built for password storage, the native PHP functions
+are maintained as part of the language and run in constant time, and every
+stored value embeds its own algorithm, cost, and salt. That self describing
+format is what lets ZubZet recognise existing hashes and upgrade them
+transparently, and it makes raising the work factor in the future a one line
+change.
+
+Existing passwords are safe and keep working. They are verified through the
+`legacy` path and re hashed onto Argon2id automatically the next time their
+owner logs in, so adopting the modern format needs no password reset.

--- a/docs/setup/upgrade/1.1.0-to-1.2.0.md
+++ b/docs/setup/upgrade/1.1.0-to-1.2.0.md
@@ -87,6 +87,13 @@ ZubZet now officially supports PHP 8.5.
 The framework has been tested against the latest PHP release and runs out of the box on 8.5, so you can take advantage of the newest language features and runtime improvements.
 Older supported PHP versions continue to work as before, allowing you to upgrade on your own schedule.
 
+### Native Argon2id Password Hashing
+
+Password storage now uses PHP's native **Argon2id**, the algorithm recommended by the current OWASP Password Storage guidance, in place of the previous SHA-512 based scheme.
+Argon2id is memory hard and purpose built for password storage, and the native PHP functions embed the algorithm, cost, and salt in every stored value.
+Existing passwords are safe and keep working: they are upgraded to Argon2id automatically the next time their owner logs in, so adopting the modern format requires no password reset.
+See the new [Password Handling documentation](../../../core-features/password-handling) for the full picture, including the verify and hash API and how to add users.
+
 
 ## Bugfixes
 
@@ -178,3 +185,23 @@ logger_enabled = false
 ```
 
 See the [Logging documentation](../../../core-features/logging) for all available options.
+
+---
+
+### 4. Adopt native password hashing
+
+The schema migration runs automatically when the framework updates. It adds a
+`password_scheme` and a `last_password_rehash_at` column to `z_user` and marks
+every existing password row as `legacy`. No action is required for accounts to
+keep working: they verify through the legacy path and upgrade themselves to
+Argon2id on the next successful login.
+
+Rehash on login only reaches accounts that log in. To bring accounts that have
+not logged in yet onto Argon2id as well, run the onion migration once. It is
+idempotent and safe to re run:
+
+```bash
+php index.php auth:migrate-hashing
+```
+
+See the [Password Handling documentation](../../../core-features/password-handling) for the verify and hash API, the scheme model, and how to add users.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -110,6 +110,7 @@ nav:
         - Views: core-features/views
         - Layouts: core-features/layouts
         - Permission System: core-features/permission-system
+        - Password Handling: core-features/password-handling
         - Localization: core-features/localization
         - Configuration: core-features/configuration
         - REST API: core-features/rest-api

--- a/src/Authentication/Commands/HashingAlgorithmMigration.php
+++ b/src/Authentication/Commands/HashingAlgorithmMigration.php
@@ -1,0 +1,65 @@
+<?php
+
+    namespace ZubZet\Framework\Authentication\Commands;
+
+    use Symfony\Component\Console\Command\Command;
+    use Symfony\Component\Console\Input\InputInterface;
+    use Symfony\Component\Console\Input\InputOption;
+    use Symfony\Component\Console\Output\OutputInterface;
+    use ZubZet\Framework\Database\Migration\Commands\Traits\DatabaseConnection;
+
+    /**
+     * Wraps every `legacy` password hash in a fresh native hash (the "onion"),
+     * protecting dormant accounts at rest against a future breach without needing
+     * the plaintext. Idempotent and reusable: it only touches rows still on the
+     * `legacy` scheme, so re-running (or running after some users have already
+     * logged in and been upgraded) is safe and does no redundant work.
+     *
+     * Requires the password_scheme migration to have run first.
+     */
+    final class HashingAlgorithmMigration extends Command {
+
+        use DatabaseConnection;
+
+        protected function configure(): void {
+            $this->setName("auth:migrate-hashing");
+            $this->setDescription(
+                "Migrate legacy password hashes to the current algorithm (onion-wrap) for at-rest protection. Idempotent."
+            );
+            $this->addOption(
+                "dry",
+                "d",
+                InputOption::VALUE_NONE,
+                "Report what would change without writing.",
+            );
+            $this->setDatabaseConnection();
+        }
+
+        protected function execute(InputInterface $in, OutputInterface $out): int {
+            $dry = (bool) $in->getOption("dry");
+
+            $rows = model("z_login")->getLegacyPasswords();
+
+            $total = \count($rows);
+            if(0 === $total) {
+                $out->writeln("<info>No legacy passwords to wrap. Nothing to do.</info>");
+                return Command::SUCCESS;
+            }
+
+            $out->writeln("<info>Found {$total} legacy password(s)…</info>");
+            if($dry) return Command::SUCCESS;
+
+            $done = 0;
+            foreach($rows as $row) {
+                $done++;
+                if($done % 100 === 0 || $done === $total) {
+                    $out->writeln("\t{$done} of {$total}");
+                }
+
+                model("z_login")->onionWrapPassword((int) $row["id"], $row["password"]);
+            }
+
+            $out->writeln("<info>Done: {$done} row(s) wrapped.</info>");
+            return Command::SUCCESS;
+        }
+    }

--- a/src/Authentication/PasswordHash/LegacyHash.php
+++ b/src/Authentication/PasswordHash/LegacyHash.php
@@ -1,0 +1,70 @@
+<?php
+
+    namespace ZubZet\Framework\Authentication\PasswordHash;
+
+    /**
+     * Verify-only shim for passwords from the retired `zubzet/password-hash-utilities`
+     * library (the "0.9" + SHA-512 scheme). Keeps `legacy`/`onion` rows verifiable
+     * so they self-heal to a native hash on login (see {@see Password}).
+     *
+     * The original scheme picked one random "pepper" character (a-z) and did not
+     * store which, so verification tries all 26 variants.
+     *
+     * @internal
+     * @deprecated Transition-only; remove once no `legacy`/`onion` rows remain.
+     */
+    final class LegacyHash {
+
+        private const CHARSET = "abcdefghijklmnopqrstuvwxyz";
+
+        /**
+         * Verify a plaintext against a stored legacy credential: either the raw
+         * SHA-512 hex (`legacy`) or that same digest wrapped in a native hash
+         * (`onion`). The stored format self-describes which, so one method covers
+         * both schemes.
+         */
+        public static function verify(string $password, string $salt, string $stored): bool {
+            $match = false;
+            foreach (self::innerHashes($password, $salt) as $candidate) {
+                if (self::digestMatches($candidate, $stored)) {
+                    $match = true;
+                    // No break: keep timing uniform across the 26 candidates.
+                }
+            }
+            return $match;
+        }
+
+        /** SHA-512 digests for every pepper variant (a-z) of the 0.9 scheme. */
+        private static function innerHashes(string $password, string $salt): array {
+            $out = [];
+            foreach (str_split(self::CHARSET) as $pepper) {
+                $out[] = hash("sha512", self::logic09($password, $salt, $pepper));
+            }
+            return $out;
+        }
+
+        /** Match one candidate digest against the stored value (raw hex, or onion-wrapped). */
+        private static function digestMatches(string $candidate, string $stored): bool {
+            if (str_starts_with($stored, "\$argon2")) {
+                return password_verify($candidate, $stored);
+            }
+            return hash_equals($stored, $candidate);
+        }
+
+        /** Exact port of the old library's "0.9" custom logic. */
+        private static function logic09(string $input, string $salt, string $pepper): string {
+            $input = base64_encode($input) . $salt . $pepper;
+            $input .= str_repeat(substr($input, 2), 2);
+            $input = strrev($input);
+            $key = $input;
+            $result = "";
+            $len = \strlen($input);
+            for ($i = 0; $i < $len; $i++) {
+                $char = substr($input, $i, 1);
+                $keyCharacter = substr($key, ($i % \strlen($key)) - 1, 1);
+                $char = chr(ord($char) + ord($keyCharacter));
+                $result .= $char;
+            }
+            return base64_encode($result);
+        }
+    }

--- a/src/Authentication/PasswordHash/Password.php
+++ b/src/Authentication/PasswordHash/Password.php
@@ -1,0 +1,116 @@
+<?php
+
+    namespace ZubZet\Framework\Authentication\PasswordHash;
+
+    use InvalidArgumentException;
+
+    /**
+     * Password hashing on PHP's native Argon2id (at PHP's default cost), the public
+     * entry point for the framework's password handling. A `password_scheme` marker
+     * lets legacy and onion-wrapped hashes coexist and self-heal to native on login.
+     *
+     * - native: `password` is a password_hash() string; `salt` is null.
+     * - legacy: `password` is the SHA-512 hex; `salt` is the per-row salt.
+     * - onion : `password` is a native hash of the SHA-512 hex; `salt` is kept.
+     */
+    final class Password {
+
+        public const NATIVE = "native";
+        public const LEGACY = "legacy";
+        public const ONION = "onion";
+
+        // The max is a DoS guard (rejected, never truncated).
+        public const MIN_LENGTH_BYTES = 3;
+        public const MAX_LENGTH_BYTES = 1024;
+
+        /**
+         * Reduced cost for the onion layer only. An un-peeled onion row is verified
+         * up to 26 times (the legacy a-z "pepper" was never stored), so the default
+         * cost would make one login multi-second and a DoS vector. Still far
+         * stronger than the bare SHA-512 it wraps, and peeled to the default on the
+         * next login.
+         */
+        private const ONION_OPTS = [
+            "memory_cost" => 12288,
+            "time_cost" => 1,
+            "threads" => 1,
+        ];
+
+        /** Create a native hash from a plaintext password. */
+        public static function hash(string $password): string {
+            // Assert the correct length
+            $length = strlen($password);
+            if(self::MIN_LENGTH_BYTES > $length || self::MAX_LENGTH_BYTES < $length) {
+                throw new InvalidArgumentException("Invalid password length.");
+            }
+
+            // Generate a new native hash
+            return password_hash($password, PASSWORD_ARGON2ID);
+        }
+
+        /**
+         * Verify a plaintext against a stored credential. `scheme` selects how to
+         * read the stored value (defaults to native); `salt` is only needed for
+         * legacy/onion rows.
+         */
+        public static function verify(string $password, string $stored, ?string $scheme = self::NATIVE, ?string $salt = null): Verification {
+            // Make sure the length is correct
+            $length = strlen($password);
+            if(empty($stored) || self::MIN_LENGTH_BYTES > $length || self::MAX_LENGTH_BYTES < $length) {
+                return Verification::createWrong();
+            }
+
+            // Verifying using the current native method
+            if(self::NATIVE === $scheme) {
+                return self::verifyNative($password, $stored);
+            }
+
+            // Verifying using the old hash method
+            if(self::LEGACY === $scheme || self::ONION === $scheme) {
+                if(empty($salt)) {
+                    throw new InvalidArgumentException("A legacy or onion hash requires a salt.");
+                }
+
+                return self::verifyLegacy($password, $salt, $stored);
+            }
+
+            // Otherwise, it can't be verified, so default wrong
+            return Verification::createWrong();
+        }
+
+        /**
+         * Wrap a stored legacy SHA-512 hex in a native hash without the plaintext.
+         * @internal The bulk-migration helper; not part of the public verify/hash API.
+         */
+        public static function onionWrap(string $legacyHash): string {
+            return password_hash($legacyHash, PASSWORD_ARGON2ID, self::ONION_OPTS);
+        }
+
+        /** Native Argon2id: matches, and self-heals when below the current cost. */
+        private static function verifyNative(string $password, string $stored): Verification {
+            // Check if the password is wrong with the native password function
+            if(false === password_verify($password, $stored)) {
+                return Verification::createWrong();
+            }
+
+            // If the password is correct, check that no change in hash is needed
+            if(false === password_needs_rehash($stored, PASSWORD_ARGON2ID)) {
+                return Verification::createCorrect();
+            }
+
+            // Otherwise the password is correct, but needs an upgrade, provide the new hash
+            return Verification::createCorrectWithUpgrade($password);
+        }
+
+        /** Legacy or onion (the shim detects which); any match self-heals to native. */
+        private static function verifyLegacy(string $password, string $salt, string $stored): Verification {
+            // Check if the password was wrong
+            if(false === LegacyHash::verify($password, $salt, $stored)) {
+                return Verification::createWrong();
+            }
+
+            // Else, it is correct, but an upgrade is always needed for legacy hashes
+            return Verification::createCorrectWithUpgrade($password);
+        }
+    }
+?>

--- a/src/Authentication/PasswordHash/Verification.php
+++ b/src/Authentication/PasswordHash/Verification.php
@@ -1,0 +1,59 @@
+<?php
+
+    namespace ZubZet\Framework\Authentication\PasswordHash;
+
+    /**
+     * The outcome of a {@see Password::verify()} call; read it via {@see isCorrect()}.
+     *
+     * When the password is correct but its stored hash is stale, it keeps the
+     * plaintext so the fresh native hash can be produced on demand (rehash-on-login).
+     * Hashing is deferred to {@see upgradePassword()}, so a plain isCorrect() check
+     * never pays for it. Immutable; obtained only from the verifier.
+     */
+    final class Verification {
+
+        private bool $correct;
+        private ?string $upgradePlaintext;
+
+        private function __construct(bool $correct, ?string $upgradePlaintext) {
+            $this->correct = $correct;
+            $this->upgradePlaintext = $upgradePlaintext;
+        }
+
+        /** Whether the supplied password was correct. */
+        public function isCorrect(): bool {
+            return $this->correct;
+        }
+
+        /** Whether a fresh hash should be persisted after this (correct) verify. */
+        public function isUpgradeNeeded(): bool {
+            return !is_null($this->upgradePlaintext);
+        }
+
+        /**
+         * The fresh native hash to persist. Run after isUpgradeNeeded()
+         * @throws \LogicException when no upgrade is pending.
+         */
+        public function upgradePassword(): string {
+            if(is_null($this->upgradePlaintext)) {
+                throw new \LogicException("No upgrade pending; guard with isUpgradeNeeded() before calling upgradePassword().");
+            }
+            return Password::hash($this->upgradePlaintext);
+        }
+
+        /** @internal The password was wrong. */
+        public static function createWrong(): self {
+            return new self(false, null);
+        }
+
+        /** @internal Correct, and the stored hash is already current. */
+        public static function createCorrect(): self {
+            return new self(true, null);
+        }
+
+        /** @internal Correct, but stale; keeps `$password` to rehash on demand. */
+        public static function createCorrectWithUpgrade(string $password): self {
+            return new self(true, $password);
+        }
+    }
+?>

--- a/src/Authentication/Permission/User.php
+++ b/src/Authentication/Permission/User.php
@@ -7,6 +7,7 @@ use ZubZet\Framework\Authentication\AuthenticationObject;
 use DateTime;
 use ZubZet\Framework\Authentication\HandleTrait;
 use ZubZet\Framework\Authentication\Organization;
+use ZubZet\Framework\Authentication\PasswordHash\Password;
 use ZubZet\Framework\Authentication\RetrievalTrait;
 
 class User extends AuthenticationObject {
@@ -151,6 +152,36 @@ class User extends AuthenticationObject {
     public function updatePassword(string $password): void {
         model('z_login')->updatePassword($this, $password);
         $this->clearFields();
+    }
+
+    /**
+     * Verify a plaintext password against this user's stored credential and, on
+     * a correct match, transparently upgrade the stored hash when it is
+     * stale (rehash-on-login / onion peel). Self-healing.
+     *
+     * This is the password-check entry point for logging a user in.
+     *
+     * @param string $password The plaintext password to check
+     * @return bool Whether the password matched
+     */
+    public function verifyPassword(string $password): bool {
+        $result = Password::verify(
+            $password,
+            $this->getField("password") ?? "",
+            $this->getField("password_scheme"),
+            $this->getField("salt"),
+        );
+
+        if(!$result->isCorrect()) return false;
+
+        if($result->isUpgradeNeeded()) {
+            model('z_login')->upgradeStoredHash(
+                $this,
+                $result->upgradePassword(),
+            );
+        }
+
+        return true;
     }
 
     public function updateOrganization(?Organization $organization): void {

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -2,19 +2,19 @@
 
     namespace ZubZet\Framework\Console;
 
-    use Symfony\Component\Console\Application as ConsoleApplication;
-    use ZubZet\Framework\Database\Migration\Commands\Migrate;
-    use ZubZet\Framework\Database\Migration\Commands\Seed;
-    use ZubZet\Framework\Database\Migration\Commands\Status;
-    use ZubZet\Framework\Database\Migration\Commands\Sync;
-    use ZubZet\Framework\Database\Migration\Commands\UnlockMigration;
     use ZubZet\Framework\Support\Commands\Startup;
+    use ZubZet\Framework\Database\Migration\Commands\Seed;
+    use ZubZet\Framework\Database\Migration\Commands\Sync;
+    use ZubZet\Framework\Database\Migration\Commands\Status;
+    use ZubZet\Framework\Database\Migration\Commands\Migrate;
+    use ZubZet\Framework\Authentication\Commands\HashingAlgorithmMigration;
+    use Symfony\Component\Console\Application as ConsoleApplication;
+    use ZubZet\Framework\Database\Migration\Commands\UnlockMigration;
     use ZubZet\Framework\Testing\Coverage\Commands\Stop as CoverageStop;
     use ZubZet\Framework\Testing\Coverage\Commands\Start as CoverageStart;
 
     class Application {
         public static function bootstrap(\z_framework $booter): ConsoleApplication {
-            // TODO: Automatically load commands from a commands directory
             $automaticallyLoadedCommands =  [];
 
             $console = new ConsoleApplication("ZubZet CLI");
@@ -27,6 +27,7 @@
                     new Sync(),
                     new Seed(),
                     new UnlockMigration(),
+                    new HashingAlgorithmMigration(),
                     new Startup(),
                     new CoverageStart(),
                     new CoverageStop(),

--- a/src/IncludedComponents/controllers/LoginController.php
+++ b/src/IncludedComponents/controllers/LoginController.php
@@ -21,82 +21,74 @@
          * @param Response $res The response object
          */
         public function action_index($req, $res) {
+            $loginModel = $req->getModel("z_login", $req->getZRoot());
 
-            //Check if user has entert information
-            if ($req->getPost("name", false) !== false) {
-
-                //Find an user
-                $user = $req->getModel("z_login", $req->getZRoot())->getUserByLogin($req->getPost("name"));
-                
-                //Username not found
-                if ($user === false) {
-                    $res->error("Username or password is wrong");
-                }
-                
-                if ($user["verified"] == NULL) {
-                    $link = $req->getRootFolder() . "login/verify";
-                    $res->error("Your account is not activated yet. Check your mails or click <a href='$link'>here</a> to resend the activation.");
-                }
-                
-                //Max login tries
-                if ($req->getModel("z_login", $req->getZRoot())->countLoginTriesByTimeSpan($user["id"], date('Y-m-d H:i:s', strtotime('-'.$req->getBooterSettings("maxLoginTriesTimespan")))) > $req->getBooterSettings("maxLoginTriesPerTimespan")) {
-
-                    /* SECURITY EMAIL */
-                    if ($req->getModel("z_login")->sendTooManyLoginsEmailByUserId($user["id"])) {
-                        
-                        $ip = $req->ip();
-
-                        if (filter_var($ip, FILTER_VALIDATE_IP) /*&& !in_array($ip, ["127.0.0.1", "::1"])*/) {
-                            
-                            $res->sendEmailToUser(
-                                $user["id"],
-                                [
-                                    "DE_Formal" => "Sicherheitsmeldung",
-                                    "en" => "Security alert"
-                                ],
-                                "email_too_many_logins.php",
-                                [
-                                    "user" => $user,
-                                    "date" => date("Y-m-d H:i:s"),
-                                    "ip" => $ip
-                                ]
-                            );
-
-                        }
-
-                    }
-
-                    $req->getModel("z_login", $req->getZRoot())->addTooManyLoginsEmailByUserId($user["id"]);
-
-                    //Log
-                    logger(Logger::ZUBZET)->warning(LogEventType::ACCOUNT_LOGIN_RATE_LIMITED, [
-                        "userId" => $user["id"]
-                    ]);
-
-                    $res->error("Too many login tries. Try again later.");
-                }
-
-                //Check the password
-                if ($req->getModel("z_login")->checkPassword(
-                    $req->getPost("password"),
-                    $user["password"],
-                    $user["salt"],
-                )) {
-                    $res->loginAs($user["id"]);
-                    $res->success();
-                } else {
-                    //Add login try
-                    $req->getModel("z_login", $req->getZRoot())->newLoginTry($user["id"]);
-                    $res->error("Username or password is wrong");
-                }
-
-            } else {
-                //else the user wants the form to login
-                $res->render("login.php", [
+            // No credentials submitted yet: render the login form.
+            if($req->getPost("name", false) === false) {
+                return $res->render("login.php", [
                     "title" => "Login ",
-                    "noLayout" => $req->getGet("noLayout", false)
+                    "noLayout" => $req->getGet("noLayout", false),
                 ], "layout/min_layout.php");
             }
+
+            // Look the account up by the submitted login (its email).
+            $user = User::byEmail($req->getPost("name"));
+
+            // Unknown account: reuse the wrong-password message so the response
+            // can't be used to probe which emails are registered.
+            if(is_null($user)) {
+                return $res->error("Username or password is wrong");
+            }
+
+            // The account exists but was never activated.
+            if(is_null($user->verified())) {
+                $link = $req->getRootFolder() . "login/verify";
+                return $res->error("Your account is not activated yet. Check your mails or click <a href='$link'>here</a> to resend the activation.");
+            }
+
+            // Too many recent attempts: warn the owner and block this try.
+            $timespanStart = date('Y-m-d H:i:s', strtotime('-' . $req->getBooterSettings("maxLoginTriesTimespan")));
+            $recentTries = $loginModel->countLoginTriesByTimeSpan($user->id(), $timespanStart);
+            $maxTries = $req->getBooterSettings("maxLoginTriesPerTimespan");
+            if($recentTries > $maxTries) {
+
+                // Warn the owner once per window, and only for a valid client IP.
+                $clientIp = filter_var($req->ip(), FILTER_VALIDATE_IP);
+                if($clientIp && $loginModel->sendTooManyLoginsEmailByUserId($user->id())) {
+                    $res->sendEmailToUser(
+                        $user->id(),
+                        [
+                            "DE_Formal" => "Sicherheitsmeldung",
+                            "en" => "Security alert",
+                        ],
+                        "email_too_many_logins.php",
+                        [
+                            "user" => $user->getAll(),
+                            "date" => date("Y-m-d H:i:s"),
+                            "ip" => $clientIp,
+                        ],
+                    );
+                }
+
+                $loginModel->addTooManyLoginsEmailByUserId($user->id());
+
+                logger(Logger::ZUBZET)->warning(LogEventType::ACCOUNT_LOGIN_RATE_LIMITED, [
+                    "userId" => $user->id(),
+                ]);
+
+                return $res->error("Too many login tries. Try again later.");
+            }
+
+            // Wrong password: record the attempt so it counts toward the rate limit.
+            if(!$user->verifyPassword($req->getPost("password"))) {
+                $loginModel->newLoginTry($user->id());
+                return $res->error("Username or password is wrong");
+            }
+
+            // Correct. verifyPassword() has already self-healed the stored hash if
+            // it was stale, so all that is left is to start the session.
+            $res->loginAs($user->id());
+            return $res->success();
         }
 
         /**

--- a/src/IncludedComponents/database/Migration/2026-05-30_password_scheme.sql
+++ b/src/IncludedComponents/database/Migration/2026-05-30_password_scheme.sql
@@ -1,0 +1,20 @@
+ALTER TABLE `z_user`
+    ADD COLUMN IF NOT EXISTS `password_scheme` VARCHAR(32) DEFAULT 'legacy'
+    COMMENT 'hashing scheme only' AFTER `password`;
+
+UPDATE `z_user`
+    SET `password_scheme` = NULL
+    WHERE `password` IS NULL OR `password` = '';
+
+ALTER TABLE `z_user`
+    ADD COLUMN IF NOT EXISTS `last_password_rehash_at` TIMESTAMP NULL DEFAULT NULL
+    COMMENT 'when the stored password hash was last (re)hashed' AFTER `password_scheme`;
+
+-- Idempotent backfill: only seed rows that have a password and are not yet stamped,
+-- using the account creation time as a lower bound on the hash's age. Passwordless
+-- rows (SSO/invite) and rows already stamped by a login rehash are left untouched.
+UPDATE `z_user`
+    SET `last_password_rehash_at` = `created`
+    WHERE `last_password_rehash_at` IS NULL
+      AND `password` IS NOT NULL
+      AND `password` <> '';

--- a/src/IncludedComponents/models/z_loginModel.php
+++ b/src/IncludedComponents/models/z_loginModel.php
@@ -5,7 +5,7 @@
 
     use ZubZet\Framework\Authentication\Session;
     use ZubZet\Framework\Database\IsInternalModel;
-    use ZubZet\Utilities\PasswordHash\PasswordHash;
+    use ZubZet\Framework\Authentication\PasswordHash\Password;
     use ZubZet\Framework\Authentication\Permission\User;
 
     /**
@@ -142,36 +142,95 @@
          * Updates the password of an user
          * @param User $user The object of the user
          * @param string $password The raw user password
-         * @deprecated
+         * @internal Replaced by the User API (@see User::updatePassword()) for external use
          */
         public function updatePassword(User $user, string $password): void {
             $user->clearSessions();
 
-            $password = PasswordHash::create(
-                $password,
-                "sha512",
-                "0.9",
-            );
-
             $sql = "UPDATE `z_user`
-                    SET `password`=?, `salt`=?
-                    WHERE `id`=?";
+                    SET
+                        `password` = ?,
+                        `password_scheme` = ?,
+                        `last_password_rehash_at` = CURRENT_TIMESTAMP(),
+                        `salt` = NULL
+                    WHERE `id` = ?";
 
             $this->exec(
                 $sql, "ssi",
-                $password->hash,
-                $password->salt,
+                Password::hash($password),
+                Password::NATIVE,
                 $user->id(),
             );
         }
 
-        public function checkPassword(string $password, string $hash, string $salt): bool {
-            return PasswordHash::checkWithoutUpdate(
-                $password,
-                $hash,
-                $salt,
-                "sha512",
-                "0.9",
+        /**
+         * Pure verification of a plaintext against a stored credential. Does NOT
+         * upgrade the stored hash — use {@see User::verifyPassword()} for the login path.
+         * @param string $password The plaintext password
+         * @param string $hash The stored `password` value
+         * @param ?string $salt The stored `salt` (legacy/onion rows need it; native ignores it)
+         * @param ?string $scheme The stored `password_scheme`; inferred from the salt when null
+         * @deprecated Use {@see \ZubZet\Framework\Authentication\PasswordHash\Password::verify()} instead.
+         */
+        public function checkPassword(string $password, string $hash, ?string $salt = null, ?string $scheme = null): bool {
+            // Older callers pass (password, hash, salt) with no scheme; infer it from the salt.
+            if(is_null($scheme)) {
+                $scheme = empty($salt) ? Password::NATIVE : Password::LEGACY;
+            }
+            return Password::verify($password, $hash, $scheme, $salt)->isCorrect();
+        }
+
+        /**
+         * Persist a freshly-upgraded native hash for a user, clearing the now
+         * obsolete salt. This is the plain DB write behind the rehash-on-login /
+         * onion-peel path; the verify-and-decide logic lives in
+         * {@see User::verifyPassword()}.
+         * @param User $user The user whose stored hash is being upgraded
+         * @param string $hash The new native Argon2id hash to store
+         */
+        public function upgradeStoredHash(User $user, string $hash): void {
+            $sql = "UPDATE `z_user`
+                    SET
+                        `password` = ?,
+                        `password_scheme` = ?,
+                        `last_password_rehash_at` = CURRENT_TIMESTAMP(),
+                        `salt` = NULL
+                    WHERE `id` = ?";
+            $this->exec($sql, "ssi", $hash, Password::NATIVE, $user->id());
+        }
+
+        /**
+         * Every `legacy` user row that still carries a hash to onion-wrap.
+         * Passwordless rows (i.e. SSO / invite) also default to `legacy` but have nothing
+         * to wrap, so they are excluded.
+         *
+         * @return array[] Rows of `id` and `password`
+         */
+        public function getLegacyPasswords(): array {
+            $sql = "SELECT `id`, `password`
+                    FROM `z_user`
+                    WHERE `password_scheme` = ?
+                    AND `password` IS NOT NULL
+                    AND `password` <> ''";
+            return $this->exec($sql, "s", Password::LEGACY)->resultToArray();
+        }
+
+        /**
+         * Onion-wraps a user's stored legacy hash in place, marking the row `onion`
+         * for at-rest protection of dormant accounts. The salt column is untouched.
+         * @param int $userId The id of the user
+         * @param string $legacyHash The stored legacy SHA-512 hash to wrap
+         */
+        public function onionWrapPassword(int $userId, string $legacyHash): void {
+            $sql = "UPDATE `z_user`
+                    SET `password` = ?, `password_scheme` = ?
+                    WHERE `id` = ?";
+            $this->exec(
+                $sql,
+                "ssi",
+                Password::onionWrap($legacyHash),
+                Password::ONION,
+                $userId,
             );
         }
 

--- a/src/IncludedComponents/models/z_userModel.php
+++ b/src/IncludedComponents/models/z_userModel.php
@@ -69,11 +69,14 @@
          * @return int The id of the new created user
          */
         function add($email, $passwordString = null, $verified = null) {
+            // A code-created user is never `legacy` (that default only serves
+            // pre-migration rows). Set the scheme NULL here; updatePassword()
+            // promotes it to `native` below when a password is given.
             if($verified === null) {
-                $query = "INSERT INTO `z_user`(`email`) VALUES (?)";
+                $query = "INSERT INTO `z_user`(`email`, `password_scheme`) VALUES (?, NULL)";
                 $this->exec($query, "s", $email);
             } else {
-                $query = "INSERT INTO `z_user`(`email`, `verified`) VALUES (?, ?)";
+                $query = "INSERT INTO `z_user`(`email`, `verified`, `password_scheme`) VALUES (?, ?, NULL)";
                 $this->exec($query, "ss", $email, $verified);
             }
             $insertId = $this->getInsertId();

--- a/tests/e2e/app/Controllers/ApiCompatProbeController.php
+++ b/tests/e2e/app/Controllers/ApiCompatProbeController.php
@@ -1,0 +1,40 @@
+<?php
+
+    use ZubZet\Framework\Authentication\PasswordHash\Password;
+
+    /**
+     * Guards the framework's password API against breaking changes for consuming
+     * apps. They call model("z_login")->checkPassword($pw, $hash, $salt) with the
+     * 3-argument shape (no scheme) on their own user tables, and rely on legacy
+     * hashes still verifying. See jouri's Authentication/UserController.
+     *
+     * If a refactor breaks the 3-arg signature or stops inferring the scheme from
+     * the salt, these probes flip and the spec fails.
+     */
+    class ApiCompatProbeController extends z_controller {
+
+        // The seeded admin's real legacy credential (zubzet/1_users.sql).
+        private const LEGACY_PW   = "password";
+        private const LEGACY_SALT = "4401287036553e310907533.22322450";
+        private const LEGACY_HASH = "772e7e18b509ee9dbf4a53d415187fa49c68c991873e3282c0025e9e53d4c946125f184c34e04a7fcd5136fcdc04bedc17afd981380ee05ccb7683e7d83ec615";
+
+        /** Consumer call: checkPassword($pw, $legacyHash, $salt) — no scheme. */
+        public function action_legacy3Arg(Request $req, Response $res) {
+            $login = $req->getModel("z_login");
+            return $res->json([
+                "correct" => $login->checkPassword(self::LEGACY_PW, self::LEGACY_HASH, self::LEGACY_SALT),
+                "wrong" => $login->checkPassword("nope", self::LEGACY_HASH, self::LEGACY_SALT),
+            ]);
+        }
+
+        /** Consumer call: checkPassword($pw, $nativeHash, null) — no scheme, no salt. */
+        public function action_native3Arg(Request $req, Response $res) {
+            $login = $req->getModel("z_login");
+            $hash = Password::hash("fresh-secret");
+            return $res->json([
+                "correct" => $login->checkPassword("fresh-secret", $hash, null),
+                "wrong" => $login->checkPassword("nope", $hash, null),
+            ]);
+        }
+    }
+?>

--- a/tests/e2e/app/Controllers/AuthProbeController.php
+++ b/tests/e2e/app/Controllers/AuthProbeController.php
@@ -85,18 +85,37 @@
             $password = $req->getGet("password", "");
 
             $row = db()->exec(
-                "SELECT `password`, `salt` FROM `z_user` WHERE `id` = ?",
+                "SELECT `password`, `salt`, `password_scheme` FROM `z_user` WHERE `id` = ?",
                 "i",
                 $userId
             )->resultToLine();
 
             $ok = !empty($row) && (bool)$req->getModel("z_login")->checkPassword(
-                $password, $row['password'], $row['salt']
+                $password, $row['password'], $row['salt'], $row['password_scheme']
             );
 
             echo json_encode([
                 'found' => !empty($row),
                 'ok'    => $ok,
+            ]);
+        }
+
+        /**
+         * The stored password_scheme for a user (legacy|onion|native|null).
+         * GET /auth-probe/scheme/<userId>
+         */
+        public function action_scheme(Request $req, Response $res): void {
+            $userId = (int)$req->getParameters(0, 1);
+
+            $row = db()->exec(
+                "SELECT `password_scheme` FROM `z_user` WHERE `id` = ?",
+                "i",
+                $userId
+            )->resultToLine();
+
+            echo json_encode([
+                'found'  => !empty($row),
+                'scheme' => $row['password_scheme'] ?? null,
             ]);
         }
     }

--- a/tests/e2e/app/Controllers/PasswordHashProbeController.php
+++ b/tests/e2e/app/Controllers/PasswordHashProbeController.php
@@ -1,0 +1,180 @@
+<?php
+
+    use ZubZet\Framework\Authentication\PasswordHash\Password;
+
+    class PasswordHashProbeController extends z_controller {
+
+        // Known-answer vector: the seeded admin's real legacy credential (password
+        // "password", per zubzet/1_users.sql). Lets verify() be exercised for the
+        // legacy/onion paths without LegacyHash's now-private internals.
+        private const LEGACY_PW   = "password";
+        private const LEGACY_SALT = "4401287036553e310907533.22322450";
+        private const LEGACY_HASH = "772e7e18b509ee9dbf4a53d415187fa49c68c991873e3282c0025e9e53d4c946125f184c34e04a7fcd5136fcdc04bedc17afd981380ee05ccb7683e7d83ec615";
+
+        public function action_hashValid(Request $req, Response $res) {
+            $hash = Password::hash("validpass");
+            return $res->json([
+                "isArgon2id" => str_starts_with($hash, "\$argon2id\$"),
+                "verifies" => password_verify("validpass", $hash),
+            ]);
+        }
+
+        public function action_hashTooShort(Request $req, Response $res) {
+            return $this->catchThrowableMessage(fn() => Password::hash("ab"));
+        }
+
+        public function action_hashTooLong(Request $req, Response $res) {
+            return $this->catchThrowableMessage(fn() => Password::hash(str_repeat("x", 1025)));
+        }
+
+        public function action_verifyNativeMatch(Request $req, Response $res) {
+            $stored = Password::hash("correct-horse");
+            $result = Password::verify("correct-horse", $stored);
+            return $res->json([
+                "ok" => $result->isCorrect(),
+                "needsUpgrade" => $result->isUpgradeNeeded(),
+            ]);
+        }
+
+        public function action_verifyNativeMismatch(Request $req, Response $res) {
+            $stored = Password::hash("correct-horse");
+            return $res->json(["ok" => Password::verify("wrong", $stored)->isCorrect()]);
+        }
+
+        public function action_verifyNativeRehash(Request $req, Response $res) {
+            // A below-cost native hash must self-heal on a correct login.
+            $stored = password_hash("correct-horse", PASSWORD_ARGON2ID, [
+                "memory_cost" => 8192,
+                "time_cost" => 1,
+                "threads" => 1,
+            ]);
+            $result = Password::verify("correct-horse", $stored);
+            return $res->json([
+                "ok" => $result->isCorrect(),
+                "needsUpgrade" => $result->isUpgradeNeeded(),
+            ]);
+        }
+
+        public function action_verifyEmptyStored(Request $req, Response $res) {
+            return $res->json(["ok" => Password::verify("anything", "")->isCorrect()]);
+        }
+
+        public function action_verifyPasswordTooShort(Request $req, Response $res) {
+            $stored = Password::hash("correct-horse");
+            return $res->json(["ok" => Password::verify("ab", $stored)->isCorrect()]);
+        }
+
+        public function action_verifyPasswordTooLong(Request $req, Response $res) {
+            $stored = Password::hash("correct-horse");
+            return $res->json(["ok" => Password::verify(str_repeat("x", 1025), $stored)->isCorrect()]);
+        }
+
+        public function action_verifyUnknownScheme(Request $req, Response $res) {
+            $stored = Password::hash("correct-horse");
+            return $res->json(["ok" => Password::verify("correct-horse", $stored, "bogus")->isCorrect()]);
+        }
+
+        public function action_verifyLegacyMatch(Request $req, Response $res) {
+            $result = Password::verify(
+                self::LEGACY_PW,
+                self::LEGACY_HASH,
+                Password::LEGACY,
+                self::LEGACY_SALT,
+            );
+            return $res->json([
+                "ok" => $result->isCorrect(),
+                "needsUpgrade" => $result->isUpgradeNeeded(),
+            ]);
+        }
+
+        public function action_verifyLegacyMismatch(Request $req, Response $res) {
+            return $res->json([
+                "ok" => Password::verify(
+                    "wrong",
+                    self::LEGACY_HASH,
+                    Password::LEGACY,
+                    self::LEGACY_SALT,
+                )->isCorrect(),
+            ]);
+        }
+
+        public function action_verifyLegacyMissingSalt(Request $req, Response $res) {
+            return $this->catchThrowableMessage(fn() => Password::verify(
+                self::LEGACY_PW,
+                self::LEGACY_HASH,
+                Password::LEGACY,
+                "",
+            ));
+        }
+
+        public function action_verifyOnionMatch(Request $req, Response $res) {
+            $onion = Password::onionWrap(self::LEGACY_HASH);
+            $result = Password::verify(
+                self::LEGACY_PW,
+                $onion,
+                Password::ONION,
+                self::LEGACY_SALT,
+            );
+            return $res->json([
+                "ok" => $result->isCorrect(),
+                "needsUpgrade" => $result->isUpgradeNeeded(),
+                "wrappedFormat" => str_starts_with($onion, "\$argon2id\$"),
+            ]);
+        }
+
+        public function action_verifyOnionMismatch(Request $req, Response $res) {
+            $onion = Password::onionWrap(self::LEGACY_HASH);
+            return $res->json([
+                "ok" => Password::verify(
+                    "wrong",
+                    $onion,
+                    Password::ONION,
+                    self::LEGACY_SALT,
+                )->isCorrect(),
+            ]);
+        }
+
+        // Calling upgradePassword() with no pending upgrade is a misuse and must throw.
+        public function action_upgradeWithoutPending(Request $req, Response $res) {
+            $stored = Password::hash("correct-horse");
+            $result = Password::verify("correct-horse", $stored);
+            return $this->catchThrowableMessage(fn() => $result->upgradePassword());
+        }
+
+        // A pending upgrade yields a fresh native hash on demand.
+        public function action_upgradePassword(Request $req, Response $res) {
+            $stored = password_hash("correct-horse", PASSWORD_ARGON2ID, [
+                "memory_cost" => 8192,
+                "time_cost" => 1,
+                "threads" => 1,
+            ]);
+            $result = Password::verify("correct-horse", $stored);
+            $upgraded = $result->upgradePassword();
+            return $res->json([
+                "isArgon2id" => str_starts_with($upgraded, "\$argon2id\$"),
+                "verifies" => password_verify("correct-horse", $upgraded),
+                "rehashed" => !password_needs_rehash($upgraded, PASSWORD_ARGON2ID),
+            ]);
+        }
+
+        // The happy-path probe keeps catchThrowableMessage's no-throw branch covered.
+        public function action_catchHelperHappyPath(Request $req, Response $res) {
+            return $this->catchThrowableMessage(fn() => null);
+        }
+
+        private function catchThrowableMessage(\Closure $action): void {
+            try {
+                $action();
+                response()->json(["threw" => false]);
+            } catch (\Throwable $e) {
+                response()->json([
+                    "threw" => true,
+                    "type" => get_class($e),
+                    "message" => $e->getMessage(),
+                ]);
+            }
+        }
+
+    }
+
+?>

--- a/tests/e2e/app/Controllers/UserController.php
+++ b/tests/e2e/app/Controllers/UserController.php
@@ -91,18 +91,37 @@ class UserController extends z_controller {
 
     public function action_updatePassword(Request $req, Response $res): void {
         $user = User::byId(119);
-        $isOldPasswordCorrect = $req->getModel("z_login")->checkPassword("password", $user->getField("password"), $user->getField("salt"));
+
+        $isOldPasswordCorrect = $req->getModel("z_login")->checkPassword(
+            "password",
+            $user->getField("password"),
+            $user->getField("salt"),
+            $user->getField("password_scheme"),
+        );
 
         $user->updatePassword("newpassword");
 
-        $user = User::byId(119); // Reload user to get updated password hash
-        $isOldPasswordCorrectAfterUpdate = $req->getModel("z_login")->checkPassword("password", $user->getField("password"), $user->getField("salt"));
-        $isNewPasswordCorrect = $req->getModel("z_login")->checkPassword("newpassword", $user->getField("password"), $user->getField("salt"));
+        // Reload user to get updated password hash
+        $user = User::byId(119);
+
+        $isOldPasswordCorrectAfterUpdate = $req->getModel("z_login")->checkPassword(
+            "password",
+            $user->getField("password"),
+            $user->getField("salt"),
+            $user->getField("password_scheme"),
+        );
+
+        $isNewPasswordCorrect = $req->getModel("z_login")->checkPassword(
+            "newpassword",
+            $user->getField("password"),
+            $user->getField("salt"),
+            $user->getField("password_scheme"),
+        );
 
         echo(json_encode([
             "isOldPasswordCorrect" => $isOldPasswordCorrect,
             "isOldPasswordCorrectAfterUpdate" => $isOldPasswordCorrectAfterUpdate,
-            "isNewPasswordCorrect" => $isNewPasswordCorrect
+            "isNewPasswordCorrect" => $isNewPasswordCorrect,
         ]));
     }
 
@@ -116,7 +135,7 @@ class UserController extends z_controller {
 
         echo(json_encode([
             "beforeVerified" => $beforeVerified,
-            "afterVerified" => $afterVerified
+            "afterVerified" => $afterVerified,
         ]));
     }
 
@@ -131,7 +150,7 @@ class UserController extends z_controller {
 
         echo(json_encode([
             "beforeVerified" => $beforeVerified,
-            "afterVerified" => $afterVerified
+            "afterVerified" => $afterVerified,
         ]));
     }
 
@@ -142,7 +161,7 @@ class UserController extends z_controller {
 
         echo(json_encode([
             "isVerifiedNow" => $isVerifiedNow,
-            "isVerifiedPast" => $isVerifiedPast
+            "isVerifiedPast" => $isVerifiedPast,
         ]));
     }
 
@@ -155,7 +174,7 @@ class UserController extends z_controller {
         echo(json_encode([
             "isVerifiedNow" => $isVerifiedNow,
             "isVerifiedPast" => $isVerifiedPast,
-            "isVerifiedFuture" => $isVerifiedFuture
+            "isVerifiedFuture" => $isVerifiedFuture,
         ]));
     }
 
@@ -186,12 +205,12 @@ class UserController extends z_controller {
         $user = User::byId($user->id());
         $createdUserGet = $this->getUser($user, false, false);
 
-        $passwordWorking = $req->getModel("z_login")->checkPassword("password123", $user->getField("password"), $user->getField("salt"));
+        $passwordWorking = $req->getModel("z_login")->checkPassword("password123", $user->getField("password"), $user->getField("salt"), $user->getField("password_scheme"));
 
         echo(json_encode([
             "createdUserDirect" => $createdUserDirect,
             "createdUserGet" => $createdUserGet,
-            "passwordWorking" => $passwordWorking
+            "passwordWorking" => $passwordWorking,
         ]));
     }
 
@@ -207,6 +226,7 @@ class UserController extends z_controller {
             "createdUserGet" => $createdUserGet,
             "passwordIsNull" => $user->getField("password") === null,
             "saltIsNull" => $user->getField("salt") === null,
+            "schemeIsNull" => $user->getField("password_scheme") === null,
         ]));
     }
 

--- a/tests/e2e/tests/cypress/e2e/authentication/api-compat.cy.js
+++ b/tests/e2e/tests/cypress/e2e/authentication/api-compat.cy.js
@@ -1,0 +1,21 @@
+// Guarantees the framework's password API stays compatible with consuming apps
+// (e.g. jouri), which call model("z_login")->checkPassword($pw, $hash, $salt) with
+// the 3-argument shape (no scheme) on their own user tables. The scheme is
+// inferred from the salt, so legacy and native hashes both keep verifying.
+
+describe('Authentication/PasswordHash - consumer API compatibility', () => {
+
+    it('verifies a legacy hash via 3-arg checkPassword (existing users)', () => {
+        cy.request('/ApiCompatProbe/legacy3Arg').then((res) => {
+            expect(res.body.correct).to.eq(true);
+            expect(res.body.wrong).to.eq(false);
+        });
+    });
+
+    it('verifies a native hash via 3-arg checkPassword (new users)', () => {
+        cy.request('/ApiCompatProbe/native3Arg').then((res) => {
+            expect(res.body.correct).to.eq(true);
+            expect(res.body.wrong).to.eq(false);
+        });
+    });
+});

--- a/tests/e2e/tests/cypress/e2e/authentication/migrate-hashing.cy.js
+++ b/tests/e2e/tests/cypress/e2e/authentication/migrate-hashing.cy.js
@@ -1,0 +1,70 @@
+// Drives the auth:migrate-hashing console command (HashingAlgorithmMigration):
+// it onion-wraps every legacy row, the wrapped rows still authenticate, a real
+// login peels a row back to native, and a re-run is a safe no-op. Commands are
+// run directly via cy.exec, the same way cy.dbSeed() invokes db:seed.
+//
+// Both users below start as `legacy` (password "password") per zubzet/1_users.sql.
+// User 3 gets logged into (peeled); user 1 is left untouched to prove the re-run
+// does not disturb already-onioned rows.
+
+describe('auth:migrate-hashing command', () => {
+    const PEELED = { id: 3, email: 'customer@zierhut-it.de' };
+    const UNTOUCHED = { id: 1, email: 'admin@zierhut-it.de' };
+    const PASSWORD = 'password';
+
+    // XDEBUG_MODE=off keeps stdout clean; cy.exec already fails on a non-zero exit.
+    const migrate = () => cy.exec('docker exec -e XDEBUG_MODE=off application php index.php auth:migrate-hashing');
+    const scheme = (id) => cy.request(`/AuthProbe/scheme/${id}`).then((r) => JSON.parse(r.body).scheme);
+    const authenticates = (id) =>
+        cy.request(`/AuthProbe/checkPassword/${id}?password=${PASSWORD}`).then((r) => JSON.parse(r.body).ok);
+    const login = (email) =>
+        cy.request({
+            method: 'POST',
+            url: '/login',
+            form: true,
+            failOnStatusCode: false,
+            body: { name: email, password: PASSWORD },
+        });
+
+    before(() => cy.dbSeed());
+
+    it('seeds rows as legacy', () => {
+        scheme(PEELED.id).then((p) => expect(p).to.eq('legacy'));
+        scheme(UNTOUCHED.id).then((p) => expect(p).to.eq('legacy'));
+    });
+
+    it('wraps every legacy row to onion, and they still authenticate', () => {
+        migrate().then((res) => {
+            expect(res.stdout).to.match(/Found \d+ legacy password/);
+            expect(res.stdout).to.match(/Done: \d+ row\(s\) wrapped/);
+        });
+        scheme(PEELED.id).then((p) => expect(p).to.eq('onion'));
+        scheme(UNTOUCHED.id).then((p) => expect(p).to.eq('onion'));
+        authenticates(PEELED.id).then((ok) => expect(ok).to.eq(true));
+        authenticates(UNTOUCHED.id).then((ok) => expect(ok).to.eq(true));
+    });
+
+    it('peels an onion row back to native on a real login', () => {
+        login(PEELED.email);
+        scheme(PEELED.id).then((p) => expect(p).to.eq('native'));
+        authenticates(PEELED.id).then((ok) => expect(ok).to.eq(true));
+        // A row nobody logged into is unaffected.
+        scheme(UNTOUCHED.id).then((p) => expect(p).to.eq('onion'));
+    });
+
+    it('is a safe no-op when re-run with no legacy rows left', () => {
+        migrate().then((res) => {
+            expect(res.stdout).to.match(/No legacy passwords to wrap/);
+        });
+        scheme(PEELED.id).then((p) => expect(p).to.eq('native'));
+        scheme(UNTOUCHED.id).then((p) => expect(p).to.eq('onion'));
+        authenticates(PEELED.id).then((ok) => expect(ok).to.eq(true));
+        authenticates(UNTOUCHED.id).then((ok) => expect(ok).to.eq(true));
+    });
+
+    it('still peels a leftover onion row after the re-run', () => {
+        login(UNTOUCHED.email);
+        scheme(UNTOUCHED.id).then((p) => expect(p).to.eq('native'));
+        authenticates(UNTOUCHED.id).then((ok) => expect(ok).to.eq(true));
+    });
+});

--- a/tests/e2e/tests/cypress/e2e/authentication/passwordhash.cy.js
+++ b/tests/e2e/tests/cypress/e2e/authentication/passwordhash.cy.js
@@ -1,0 +1,147 @@
+// Drives the PasswordHash module through PasswordHashProbeController, via its
+// public Password facade. Each probe returns only the Verification fields the
+// assertion needs.
+//
+// Coverage target: every reachable line/branch in Password, Verification and
+// LegacyHash.
+
+describe('Authentication/PasswordHash', () => {
+
+    describe('Password::hash()', () => {
+        it('produces an argon2id hash that verifies', () => {
+            cy.request('/PasswordHashProbe/hashValid').then((res) => {
+                expect(res.body.isArgon2id).to.eq(true);
+                expect(res.body.verifies).to.eq(true);
+            });
+        });
+
+        it('throws for a password shorter than the minimum', () => {
+            cy.request('/PasswordHashProbe/hashTooShort').then((res) => {
+                expect(res.body.threw).to.eq(true);
+                expect(res.body.type).to.eq('InvalidArgumentException');
+                expect(res.body.message).to.match(/Invalid password length/);
+            });
+        });
+
+        it('throws for a password longer than the maximum', () => {
+            cy.request('/PasswordHashProbe/hashTooLong').then((res) => {
+                expect(res.body.threw).to.eq(true);
+                expect(res.body.type).to.eq('InvalidArgumentException');
+            });
+        });
+    });
+
+    describe('Password::verify() native', () => {
+        it('matches a current-cost hash with no upgrade', () => {
+            cy.request('/PasswordHashProbe/verifyNativeMatch').then((res) => {
+                expect(res.body.ok).to.eq(true);
+                expect(res.body.needsUpgrade).to.eq(false);
+            });
+        });
+
+        it('rejects a wrong password', () => {
+            cy.request('/PasswordHashProbe/verifyNativeMismatch').then((res) => {
+                expect(res.body.ok).to.eq(false);
+            });
+        });
+
+        it('upgrades a below-cost hash on a correct login (rehash-on-login)', () => {
+            cy.request('/PasswordHashProbe/verifyNativeRehash').then((res) => {
+                expect(res.body.ok).to.eq(true);
+                expect(res.body.needsUpgrade).to.eq(true);
+            });
+        });
+    });
+
+    describe('Password::verify() guards', () => {
+        it('rejects an empty stored value', () => {
+            cy.request('/PasswordHashProbe/verifyEmptyStored').then((res) => {
+                expect(res.body.ok).to.eq(false);
+            });
+        });
+
+        it('rejects a password below the minimum length', () => {
+            cy.request('/PasswordHashProbe/verifyPasswordTooShort').then((res) => {
+                expect(res.body.ok).to.eq(false);
+            });
+        });
+
+        it('rejects a password above the maximum length', () => {
+            cy.request('/PasswordHashProbe/verifyPasswordTooLong').then((res) => {
+                expect(res.body.ok).to.eq(false);
+            });
+        });
+
+        it('rejects an unknown scheme', () => {
+            cy.request('/PasswordHashProbe/verifyUnknownScheme').then((res) => {
+                expect(res.body.ok).to.eq(false);
+            });
+        });
+    });
+
+    describe('Password::verify() legacy', () => {
+        it('verifies a legacy hash and yields a native upgrade', () => {
+            cy.request('/PasswordHashProbe/verifyLegacyMatch').then((res) => {
+                expect(res.body.ok).to.eq(true);
+                expect(res.body.needsUpgrade).to.eq(true);
+            });
+        });
+
+        it('rejects a wrong password against a legacy hash', () => {
+            cy.request('/PasswordHashProbe/verifyLegacyMismatch').then((res) => {
+                expect(res.body.ok).to.eq(false);
+            });
+        });
+
+        it('throws when a legacy hash has no salt', () => {
+            cy.request('/PasswordHashProbe/verifyLegacyMissingSalt').then((res) => {
+                expect(res.body.threw).to.eq(true);
+                expect(res.body.type).to.eq('InvalidArgumentException');
+            });
+        });
+    });
+
+    describe('Password::verify() onion (+ Password::onionWrap)', () => {
+        it('wraps a legacy hash, verifies it, and yields a native upgrade', () => {
+            cy.request('/PasswordHashProbe/verifyOnionMatch').then((res) => {
+                expect(res.body.wrappedFormat).to.eq(true);
+                expect(res.body.ok).to.eq(true);
+                expect(res.body.needsUpgrade).to.eq(true);
+            });
+        });
+
+        it('rejects a wrong password against an onion hash', () => {
+            cy.request('/PasswordHashProbe/verifyOnionMismatch').then((res) => {
+                expect(res.body.ok).to.eq(false);
+            });
+        });
+    });
+
+    describe('Verification::upgradePassword()', () => {
+        it('produces a fresh, current-cost native hash when an upgrade is pending', () => {
+            cy.request('/PasswordHashProbe/upgradePassword').then((res) => {
+                expect(res.body.isArgon2id).to.eq(true);
+                expect(res.body.verifies).to.eq(true);
+                expect(res.body.rehashed).to.eq(true);
+            });
+        });
+
+        it('throws when called with no pending upgrade (misuse)', () => {
+            cy.request('/PasswordHashProbe/upgradeWithoutPending').then((res) => {
+                expect(res.body.threw).to.eq(true);
+                expect(res.body.type).to.eq('LogicException');
+                expect(res.body.message).to.match(/No upgrade pending/);
+            });
+        });
+    });
+
+    // Keeps the probe helper at 100%: every other action routes a (sometimes
+    // throwing) closure through catchThrowableMessage; this is its no-throw arm.
+    describe('probe helper', () => {
+        it('reports threw=false when the closure succeeds', () => {
+            cy.request('/PasswordHashProbe/catchHelperHappyPath').then((res) => {
+                expect(res.body.threw).to.eq(false);
+            });
+        });
+    });
+});

--- a/tests/e2e/tests/cypress/e2e/permission/user.cy.js
+++ b/tests/e2e/tests/cypress/e2e/permission/user.cy.js
@@ -260,6 +260,7 @@ describe('Permission System - User', () => {
             expect(output.createdUserGet).to.deep.equal(output.createdUserDirect);
             expect(output.passwordIsNull).to.equal(true);
             expect(output.saltIsNull).to.equal(true);
+            expect(output.schemeIsNull).to.equal(true);
         });
     });
 


### PR DESCRIPTION
## Summary

Modernises password storage onto PHP's native Argon2id, the algorithm recommended by current OWASP guidance, in place of the previous SHA-512 based scheme. Existing passwords stay valid and upgrade themselves to Argon2id on the next login, so no reset is required.

## What changed

- New `Authentication\PasswordHash` module: `Password` (hash and verify), the `Verification` value object, and a verify-only `LegacyHash` shim. Removes the `zubzet/password-hash-utilities` dependency.
- Self-describing `password_scheme` column (`native`, `legacy`, `onion`) and a `last_password_rehash_at` timestamp on `z_user`.
- `User::verifyPassword()` self-heals a stale stored hash on a correct login (rehash-on-login); the login flow now routes through it.
- `auth:migrate-hashing` command onion-wraps dormant `legacy` rows onto Argon2id ahead of their next login. Idempotent.
- Docs: a Password Handling page, upgrade notes in the 1.1.0 to 1.2.0 guide, and changelog entries.

## Compatibility

Existing accounts keep working unchanged. The 3-argument `z_loginModel::checkPassword()` still works and is deprecated in favour of `Password::verify()` and `User::verifyPassword()`.

## Testing

- Full e2e suite green: 594 tests (3 pre-existing pending).
- PasswordHash module at 100% line coverage; the model, User and controller paths are exercised by the suite.
