### PR TITLE
fix(database): guard heartbeat against unopened lazy connection

### DIFF
--- a/src/Core/Model.php
+++ b/src/Core/Model.php
@@ -117,6 +117,11 @@
 
         /**
          * Runs a very lightweight query to keep the connection alive.
+         *
+         * @deprecated since 1.2.0 Connections self-heal on use via the database
+         *     layer's assertConnection(); manual keep-alive loops are no longer
+         *     necessary. Remove your heartbeat() calls.
+         *
          * @param bool $waitForTimeout If set to true, only ping if no other query has been made within the timeout period
          * @return void
          */

--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -110,15 +110,11 @@
                 return;
             }
 
-            // Try a heartbeat to see if the connection is still alive
-            $connectionAlive = false;
-
-            try {
-                $connectionAlive = $this->heartbeat(waitForTimeout: false);
-            } catch(\Exception) {} finally {
-                if(!$connectionAlive) {
-                    $this->connect();
-                }
+            // The connection may have gone stale while idle; verify it with a
+            // ping and reconnect if it no longer responds.
+            $this->lastHeartbeat = time();
+            if(!$this->pingConnection()) {
+                $this->connect();
             }
         }
 
@@ -306,8 +302,18 @@
         }
 
         /**
-         * Run a very lightweight query to keep the connection alive
-         * @return bool Was the heartbeat successful
+         * Run a very lightweight query to keep the connection alive.
+         *
+         * @deprecated since 1.2.0 The connection now self-heals on use via
+         *     assertConnection(), so a manual keep-alive loop is no longer
+         *     necessary. Simply remove your heartbeat() calls and let queries
+         *     transparently (re)connect as needed. Kept for backward
+         *     compatibility with existing worker loops.
+         *
+         * @param bool $waitForTimeout Only ping if no heartbeat happened within the timeout window
+         * @param int $timeoutBuffer Seconds subtracted from the timeout before a ping is forced
+         * @return bool Whether a live connection responded. False when no
+         *     connection has been opened yet (lazy loading) or the ping failed.
          */
         public function heartbeat($waitForTimeout = true, $timeoutBuffer = 30): bool {
             if($waitForTimeout && isset($this->lastHeartbeat)) {
@@ -317,7 +323,26 @@
                     return true;
                 }
             }
+
+            // Connections are opened lazily on first use, so there may be
+            // nothing to keep alive yet. Report the connection as not-alive
+            // instead of fatally reading the uninitialized mysqli handle; this
+            // lets callers decide to (re)connect on their own terms. Before
+            // lazy loading this branch was unreachable because the connection
+            // was always opened in the constructor.
+            if(!isset($this->conn)) return false;
+
             $this->lastHeartbeat = time();
+            return $this->pingConnection();
+        }
+
+        /**
+         * Sends a lightweight query to check whether an already-established
+         * connection is still responding. Assumes a connection has been opened.
+         *
+         * @return bool True if the server answered, false if the connection is dead
+         */
+        private function pingConnection(): bool {
             // mysqli::ping() is deprecated since PHP 8.4 (the reconnect
             // feature was removed in 8.2, leaving ping redundant). A
             // lightweight SELECT 1 round-trips the server identically and

--- a/tests/e2e/app/Controllers/ConnectionProbeController.php
+++ b/tests/e2e/app/Controllers/ConnectionProbeController.php
@@ -79,6 +79,26 @@
             ]);
         }
 
+        // Regression guard for the lazy-loading change: a freshly constructed
+        // Connection opens no socket, so its typed \mysqli $conn property is
+        // uninitialized. Calling heartbeat() on it used to fatal with "Typed
+        // property ...::$conn must not be accessed before initialization" once
+        // the connection stopped being opened eagerly in the constructor.
+        // It must now report not-alive instead of throwing, so existing worker
+        // keep-alive loops keep working after upgrading. A fresh instance is
+        // used (rather than db()) so the uninitialized state is guaranteed
+        // regardless of what else the request touched.
+        public function action_heartbeatBeforeConnect(Request $req, Response $res) {
+            $threw = false;
+            $alive = null;
+            try {
+                $alive = (new Connection())->heartbeat(false);
+            } catch (\Throwable $e) {
+                $threw = true;
+            }
+            return $res->json(["threw" => $threw, "alive" => $alive]);
+        }
+
         // -------------------------------------------------------------
         // assertConnection() - happy + stale-then-heartbeat. The
         // heartbeat-fails-then-reconnect branch is intentionally out of

--- a/tests/e2e/tests/cypress/e2e/database/connection.cy.js
+++ b/tests/e2e/tests/cypress/e2e/database/connection.cy.js
@@ -2,9 +2,9 @@
 // Sections mirror the controller; each describe owns one method.
 //
 // Coverage target: every reachable line in Connection.php. The single
-// branch we cannot reach (assertConnection's heartbeat-fails-then-
-// reconnect path on Connection.php:118-122) requires MySQL fault
-// injection and is documented as out of scope.
+// branch we cannot reach (assertConnection's ping-fails-then-reconnect
+// path, where pingConnection() returns false and connect() runs) requires
+// MySQL fault injection and is documented as out of scope.
 
 describe('Database/Connection', () => {
     before(() => cy.dbSeed());
@@ -61,6 +61,18 @@ describe('Database/Connection', () => {
                 expect(res.body.first).to.eq(true);
                 expect(res.body.second).to.eq(true);
                 expect(res.body.lastHeartbeatStable, 'second call did NOT update lastHeartbeat').to.eq(true);
+            });
+        });
+
+        // Regression: with lazy-loaded connections a Connection can exist
+        // before its socket is opened. heartbeat() must not touch the
+        // uninitialized $conn (which fataled with a typed-property Error);
+        // it now returns false without throwing. This pins backward
+        // compatibility for worker keep-alive loops on future upgrades.
+        it('does not fatal before the lazy connection is opened (returns not-alive)', () => {
+            cy.request('/ConnectionProbe/heartbeatBeforeConnect').then((res) => {
+                expect(res.body.threw, 'heartbeat() must not throw before the connection is opened').to.eq(false);
+                expect(res.body.alive).to.eq(false);
             });
         });
     });


### PR DESCRIPTION
## What
heartbeat() read the typed mysqli $conn before the lazy connection was opened, causing a fatal "must not be accessed before initialization" on worker loops that ping before any query was run.

## Fix
- Guard the unopened case so heartbeat() returns false instead of crashing
- Extract the liveness probe into a private pingConnection(), now used by assertConnection()
- Deprecate heartbeat() and Model::heartbeat() since connections self heal on use
- Add a regression test that fails before this change and passes after

## Tests
database/connection (18), database/interaction (6) and core/model (6) all pass.
