### PR TITLE
fix(authentication): share permissionChanged flag via base class

### DIFF
--- a/src/Authentication/AuthenticationObject.php
+++ b/src/Authentication/AuthenticationObject.php
@@ -4,6 +4,19 @@ namespace ZubZet\Framework\Authentication;
 
 class AuthenticationObject {
 
+    /**
+     * Process-wide flag indicating that permission-related data has changed.
+     *
+     * Declared once on the base class (and never redeclared in the trait or
+     * subclasses) so that User, Role and Group all share a single storage slot.
+     * When true, cached permissions are reloaded on each access, regardless of
+     * which authentication object triggered the change.
+     *
+     * @var bool
+     */
+    protected static bool $permissionChanged = false;
+
+
     /** @var int The ID of the authentication object */
     private ?int $id = null;
 

--- a/src/Authentication/Permission/Permission.php
+++ b/src/Authentication/Permission/Permission.php
@@ -4,10 +4,6 @@ namespace ZubZet\Framework\Authentication\Permission;
 
 trait Permission {
 
-    // Indicate if permissions have changed globally
-    // If true, permissions will be reloaded for each access
-    protected static $permissionChanged = false;
-
     /**
      * Add permissions to an permission object (user or role)
      *

--- a/src/Authentication/Permission/Role.php
+++ b/src/Authentication/Permission/Role.php
@@ -139,8 +139,7 @@ class Role extends AuthenticationObject {
      * @return void
      */
     public function remove(): void {
-        global $permissionChanged;
-        $permissionChanged = true;
+        self::$permissionChanged = true;
         model("z_permission")->removeRoleGroup($this);
 
         $this->clearFields();
@@ -182,12 +181,9 @@ class Role extends AuthenticationObject {
      * @return string[] The permissions associated with this role
      */
     public function getPermissions(): array {
-        // Check if permissions data is changed.
-        // This is necessary to ensure that any updates to permissions are reflected
-        global $permissionChanged;
-
         // Refresh permissions if they are null or if there has been a change
-        if(is_null($this->getField("permissions")) || $permissionChanged) $this->refreshPermissions();
+        // anywhere (see AuthenticationObject::$permissionChanged)
+        if(is_null($this->getField("permissions")) || self::$permissionChanged) $this->refreshPermissions();
 
         return $this->getField("permissions");
     }

--- a/src/Authentication/Permission/User.php
+++ b/src/Authentication/Permission/User.php
@@ -185,8 +185,7 @@ class User extends AuthenticationObject {
      */
     public function remove(): void {
         // Setting permission changed to true to indicate permissions need to be reloaded
-        global $permissionChanged;
-        $permissionChanged = true;
+        self::$permissionChanged = true;
 
         model("z_permission")->removeUser($this);
         $this->clearFields();
@@ -215,8 +214,7 @@ class User extends AuthenticationObject {
      */
     public function rolesAdd(Role ...$roles): void {
         // Setting permission changed to true to indicate permissions need to be reloaded
-        global $permissionChanged;
-        $permissionChanged = true;
+        self::$permissionChanged = true;
 
         // Add roles to user in the database
         model("z_permission")->addRolesGroupsToUser($this, ...$roles);
@@ -234,8 +232,7 @@ class User extends AuthenticationObject {
      */
     public function groupsAdd(Group ...$groups): void {
         // Setting permission changed to true to indicate permissions need to be reloaded
-        global $permissionChanged;
-        $permissionChanged = true;
+        self::$permissionChanged = true;
 
         // Add groups to user in the database
         model("z_permission")->addRolesGroupsToUser($this, ...$groups);
@@ -253,8 +250,7 @@ class User extends AuthenticationObject {
      */
     public function rolesRemove(Role ...$roles): void {
         // Setting permission changed to true to indicate permissions need to be reloaded
-        global $permissionChanged;
-        $permissionChanged = true;
+        self::$permissionChanged = true;
 
         // Remove roles from user in the database
         model("z_permission")->removeRolesGroupsFromUser($this, ...$roles);
@@ -272,8 +268,7 @@ class User extends AuthenticationObject {
      */
     public function groupsRemove(Group ...$groups): void {
         // Setting permission changed to true to indicate permissions need to be reloaded
-        global $permissionChanged;
-        $permissionChanged = true;
+        self::$permissionChanged = true;
 
         // Remove groups from user in the database
         model("z_permission")->removeRolesGroupsFromUser($this, ...$groups);
@@ -363,9 +358,7 @@ class User extends AuthenticationObject {
      * @return string[] Array of permissions
      */
     public function getUserPermissions(): array {
-        global $permissionChanged;
-
-        if(is_null($this->getField("user-permissions")) || $permissionChanged) $this->refreshPermissions();
+        if(is_null($this->getField("user-permissions")) || self::$permissionChanged) $this->refreshPermissions();
 
         return $this->getField("user-permissions");
     }
@@ -376,9 +369,7 @@ class User extends AuthenticationObject {
      * @return string[] Array of permissions
      */
     public function getPermissions(): array {
-        global $permissionChanged;
-
-        if(is_null($this->getField("permissions")) || $permissionChanged) $this->refreshAllPermissions();
+        if(is_null($this->getField("permissions")) || self::$permissionChanged) $this->refreshAllPermissions();
 
         return $this->getField("permissions");
     }


### PR DESCRIPTION
## What

Replaces the `global $permissionChanged` state in `Role` and `User` with a single static `bool` declared on the shared base class `AuthenticationObject`.

## Why

The `Permission` trait declared its own per-class static `$permissionChanged`, but every reader (`getPermissions`, `getUserPermissions`) and most writers consulted an unrelated `global` instead. The two were never the same variable, so trait writes did not invalidate cached permissions across instances.

Declaring the flag once on the base (and never redeclaring it in the trait or subclasses) gives `User`, `Role` and `Group` one shared storage slot, restoring process-wide cross-instance invalidation with zero global state.

## Notes

- Behavior preserving for the existing global-based mutators.
- Also fixes the latent disconnect so `permissionsAdd` / `permissionsRemove` now correctly trigger cross-instance invalidation, as the dead trait static originally intended.
- `php -l` clean on all four files; PHP 8.0 to 8.5 compatible.