### PR TITLE
chore(composer): trim published package via .gitattributes export-ignore

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,16 @@
+# Keep the Composer dist archive lean.
+#
+# Composer downloads the dist archive that the git host builds with
+# `git archive`, which honors these `export-ignore` rules. Files listed
+# here are excluded from the published package but stay in the repo, so
+# development, CI, and docs are unaffected. Only src/ and web/ are needed
+# at runtime; everything below is tooling, tests, or docs.
+/tests           export-ignore
+/.github         export-ignore
+/.vscode         export-ignore
+/.gitattributes  export-ignore
+/.gitignore      export-ignore
+/mkdocs.yml      export-ignore
+/AGENTS.md       export-ignore
+/TODO            export-ignore
+/composer.lock   export-ignore


### PR DESCRIPTION
Adds `.gitattributes` `export-ignore` rules so Composer's dist archive ships only `src/`, `web/`, and essential metadata (~2.8M → ~730K). Files stay in the repo; only the published package is trimmed.

Closes #176