### PR TITLE
feat(database): retry transient cluster errors in exec()

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,7 +62,10 @@ classes before surfacing them, sharing the `db_max_retries` budget (default
   The recovery loop lives in `execWithRecovery()` with a single
   classification point; `attemptStatement()` makes one self-contained
   attempt and folds PHP 8.0 false-returns and PHP 8.1+ exceptions into one
-  failure descriptor, reading the SQLSTATE off the handle that recorded it.
+  `StatementFailure` (`src/Database/StatementFailure.php`), reading the
+  SQLSTATE off the handle that recorded it. Its two named constructors,
+  `preparing()` and `executing()`, pick the error prefix from the phase the
+  attempt died in.
 
 Transport settings live in `src/Database/Endpoint.php`, a request-wide
 singleton (`Endpoint::get()`) shared by the runtime connection and the

--- a/docs/contributing/agents/working-with-agents.md
+++ b/docs/contributing/agents/working-with-agents.md
@@ -101,6 +101,7 @@ Defined in `src/Support/GlobalReferences.php`, all wrapped with `FunctionConflic
 | `request()` | Current `Request` |
 | `response()` | Current `Response` |
 | `config($key=null, $useDefault=true, $default=null)` | Booter setting value, or array of all settings |
+| `configNumeric($key, $default)` | Booter setting as `int`, throwing on a non-numeric value |
 | `user()` | `User` (currently logged-in) |
 | `db($connection="default")` | `Connection` |
 | `model($name, $dir=null)` | Model instance |

--- a/docs/core-features/global-helper-functions.md
+++ b/docs/core-features/global-helper-functions.md
@@ -82,6 +82,26 @@ config("db_username");
 
 ---
 
+### `configNumeric()`
+
+Retrieves a [configuration value](configuration.md) that has to be a number.
+
+**Syntax:** `configNumeric(string $key, int $default)`
+
+* **$key**: The configuration identifier.
+* **$default**: The value to return if the key is missing.
+
+**Note:** Non-numeric values are rejected with an `InvalidArgumentException` instead of being cast. A typo or a value like `off` would otherwise silently become `0` and disable whatever the setting controls.
+
+**Example:**
+
+```php
+configNumeric("db_max_retries", 3);
+
+```
+
+---
+
 ### `user()`
 
 Returns the instance of the [currently authenticated user](../api/classes/ZubZet-Framework-Authentication-User.html).

--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -164,7 +164,9 @@
             if(false === $connected || $conn->connect_errno) {
                 $message = (string) $conn->connect_error;
                 if("" === $message) {
-                    $message = "Cannot connect to MySQL";
+                    $message = $endpoint->tls
+                        ? "Cannot connect to MySQL using SSL"
+                        : "Cannot connect to MySQL";
                 }
                 throw new \mysqli_sql_exception($message, (int) $conn->connect_errno);
             }
@@ -323,9 +325,14 @@
             while(true) {
                 $failure = $this->attemptStatement($query, $bindArgs, $reconnect);
                 if(is_null($failure)) return;
+                if($attempt >= $this->maxRetries) throw $failure->exception;
 
-                if($this->shouldRetry($attempt, $failure->errorCode, $failure->sqlState)) {
-                    $attempt++;
+                $attempt++;
+
+                $transient = in_array($failure->errorCode, self::RETRYABLE_ERROR_CODES, true)
+                    || (!is_null($failure->sqlState) && in_array($failure->sqlState, self::RETRYABLE_SQL_STATES, true));
+
+                if($transient) {
                     // A transient failure always leaves a live connection:
                     // connect() failures only carry connection-loss codes,
                     // never transient ones, so no reconnect is needed here.
@@ -334,10 +341,9 @@
                     continue;
                 }
 
-                if($this->shouldReconnect($attempt, $failure->errorCode)) {
-                    $attempt++;
+                if(in_array($failure->errorCode, self::CONNECTION_LOSS_ERROR_CODES, true)) {
                     $reconnect = true;
-                    usleep($this->reconnectBackoffUs($attempt));
+                    usleep(min($attempt * self::RECONNECT_BACKOFF_STEP_US, self::RECONNECT_BACKOFF_CAP_US));
                     continue;
                 }
 
@@ -387,40 +393,6 @@
             }
 
             return null;
-        }
-
-        /**
-         * Whether a just-failed query should be retried: there must be retry
-         * budget left and the error must be a transient, cluster-related one.
-         */
-        private function shouldRetry(int $attempt, int $errorCode, ?string $sqlState): bool {
-            return $attempt < $this->maxRetries && $this->isRetryable($errorCode, $sqlState);
-        }
-
-        /**
-         * Whether a just-failed query should be recovered by reconnecting:
-         * there must be retry budget left and the error must mean the
-         * connection itself is gone.
-         */
-        private function shouldReconnect(int $attempt, int $errorCode): bool {
-            return $attempt < $this->maxRetries
-                && in_array($errorCode, self::CONNECTION_LOSS_ERROR_CODES, true);
-        }
-
-        /** Attempt-scaled backoff slept before a reconnect attempt. */
-        private function reconnectBackoffUs(int $attempt): int {
-            return min($attempt * self::RECONNECT_BACKOFF_STEP_US, self::RECONNECT_BACKOFF_CAP_US);
-        }
-
-        /**
-         * Classifies an error as retryable. Retries are limited to transient
-         * contention errors where the server already discarded the statement,
-         * making a re-run safe. Pure decision, no side effects.
-         */
-        private function isRetryable(int $errorCode, ?string $sqlState): bool {
-            if(in_array($errorCode, self::RETRYABLE_ERROR_CODES, true)) return true;
-            if(!is_null($sqlState) && in_array($sqlState, self::RETRYABLE_SQL_STATES, true)) return true;
-            return false;
         }
 
         /**

--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -356,33 +356,41 @@
          *
          * mysqli reports failures by throwing under PHP 8.1+ strict
          * reporting and by return value on PHP 8.0; both are captured here,
-         * reading the SQLSTATE from the handle that recorded it.
+         * reading the SQLSTATE from the handle that recorded it. The two
+         * phases are guarded separately so each one names its own error
+         * prefix, on the return-value path as well as the throwing one.
          */
         private function attemptStatement(string $query, array $bindArgs, bool $reconnect): ?array {
+            // Reaching the server and preparing the statement.
             try {
-                $errorPrefix = "SQL Error";
                 if($reconnect) $this->connect();
 
                 $statement = $this->conn->prepare($query);
                 if(is_bool($statement)) {
-                    return $this->failure($errorPrefix, $this->conn->errno, $this->conn->sqlstate, $this->conn->error, $query);
+                    return $this->failure("SQL Error", $this->conn->errno, $this->conn->sqlstate, $this->conn->error, $query);
                 }
                 $this->stmt = $statement;
 
                 // PHP 8's mysqli throws ArgumentCountError / ValueError when
                 // the type string or value count doesn't match the prepared
                 // statement; bind_param() no longer returns false in any
-                // reachable scenario.
+                // reachable scenario. Neither is a mysqli_sql_exception, so
+                // both leave the recovery loop and surface to the caller.
                 if(!empty($bindArgs)) $this->stmt->bind_param(...$bindArgs);
-
-                $errorPrefix = "SQL Execution Error";
-                if(!$this->stmt->execute()) {
-                    return $this->failure($errorPrefix, $this->stmt->errno, $this->stmt->sqlstate, $this->stmt->error, $query);
-                }
-                return null;
             } catch(\mysqli_sql_exception $error) {
-                return $this->failure($errorPrefix, (int) $error->getCode(), $this->sqlStateOf($error), $error->getMessage(), $query, $error);
+                return $this->failure("SQL Error", (int) $error->getCode(), $this->sqlStateOf($error), $error->getMessage(), $query, $error);
             }
+
+            // Running it.
+            try {
+                if(!$this->stmt->execute()) {
+                    return $this->failure("SQL Execution Error", $this->stmt->errno, $this->stmt->sqlstate, $this->stmt->error, $query);
+                }
+            } catch(\mysqli_sql_exception $error) {
+                return $this->failure("SQL Execution Error", (int) $error->getCode(), $this->sqlStateOf($error), $error->getMessage(), $query, $error);
+            }
+
+            return null;
         }
 
         /**

--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -141,35 +141,31 @@
             $host = $endpoint->host;
             if($this->persistent) $host = "p:" . $host;
 
-            // PHP 8.1+ strict reporting throws a mysqli_sql_exception naming
-            // the real failure; PHP 8.0 returns false and raises warnings
-            // instead, leaving connect_error empty for TLS failures. Collect
-            // the warnings and normalize, so both versions throw the same
-            // exception with the same message and the caller's retry
-            // classification sees the real error code.
+            // A failing connect raises warnings next to the failure itself on
+            // every PHP version. "@" keeps them out of the response and away
+            // from the framework's error handler, which promotes warnings to
+            // an ErrorException under BehaviorOption::ALL - thrown from inside
+            // real_connect(), where the retry classification never sees it.
             // Positional arguments because mysqli renamed its parameters
             // between PHP versions.
-            $warnings = [];
-            set_error_handler(function(int $severity, string $message) use (&$warnings): bool {
-                $warnings[] = $message;
-                return true;
-            });
-            try {
-                $connected = $conn->real_connect(
-                    $host,
-                    $this->user,
-                    $this->password,
-                    $this->database,
-                    $endpoint->port,
-                    null,
-                    $flags,
-                );
-            } finally {
-                restore_error_handler();
-            }
+            $connected = @$conn->real_connect(
+                $host,
+                $this->user,
+                $this->password,
+                $this->database,
+                $endpoint->port,
+                null,
+                $flags,
+            );
+
+            // PHP 8.1+ throws the real failure before returning. PHP 8.0
+            // returns false instead and leaves connect_error empty for TLS
+            // failures, so that case is normalized to what 8.1+ would report.
             if(false === $connected || $conn->connect_errno) {
                 $message = (string) $conn->connect_error;
-                if("" === $message) $message = (string) ($warnings[0] ?? "");
+                if("" === $message) {
+                    $message = "Cannot connect to MySQL";
+                }
                 throw new \mysqli_sql_exception($message, (int) $conn->connect_errno);
             }
 

--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -328,7 +328,7 @@
                 $failure = $this->attemptStatement($query, $bindArgs, $reconnect);
                 if(is_null($failure)) return;
 
-                if($this->shouldRetry($attempt, $failure["errorCode"], $failure["sqlState"])) {
+                if($this->shouldRetry($attempt, $failure->errorCode, $failure->sqlState)) {
                     $attempt++;
                     // A transient failure always leaves a live connection:
                     // connect() failures only carry connection-loss codes,
@@ -338,21 +338,21 @@
                     continue;
                 }
 
-                if($this->shouldReconnect($attempt, $failure["errorCode"])) {
+                if($this->shouldReconnect($attempt, $failure->errorCode)) {
                     $attempt++;
                     $reconnect = true;
                     usleep($this->reconnectBackoffUs($attempt));
                     continue;
                 }
 
-                throw $failure["exception"];
+                throw $failure->exception;
             }
         }
 
         /**
          * Makes one attempt at the statement: reconnect when asked to,
-         * prepare, bind, execute. Returns null on success and a failure
-         * descriptor (see failure()) otherwise.
+         * prepare, bind, execute. Returns null on success and a
+         * StatementFailure otherwise.
          *
          * mysqli reports failures by throwing under PHP 8.1+ strict
          * reporting and by return value on PHP 8.0; both are captured here,
@@ -360,14 +360,14 @@
          * phases are guarded separately so each one names its own error
          * prefix, on the return-value path as well as the throwing one.
          */
-        private function attemptStatement(string $query, array $bindArgs, bool $reconnect): ?array {
+        private function attemptStatement(string $query, array $bindArgs, bool $reconnect): ?StatementFailure {
             // Reaching the server and preparing the statement.
             try {
                 if($reconnect) $this->connect();
 
                 $statement = $this->conn->prepare($query);
                 if(is_bool($statement)) {
-                    return $this->failure("SQL Error", $this->conn->errno, $this->conn->sqlstate, $this->conn->error, $query);
+                    return StatementFailure::preparing($this->conn->errno, $this->conn->sqlstate, $this->conn->error, $query);
                 }
                 $this->stmt = $statement;
 
@@ -378,33 +378,19 @@
                 // both leave the recovery loop and surface to the caller.
                 if(!empty($bindArgs)) $this->stmt->bind_param(...$bindArgs);
             } catch(\mysqli_sql_exception $error) {
-                return $this->failure("SQL Error", (int) $error->getCode(), $this->sqlStateOf($error), $error->getMessage(), $query, $error);
+                return StatementFailure::preparing((int) $error->getCode(), $this->sqlStateOf($error), $error->getMessage(), $query, $error);
             }
 
             // Running it.
             try {
                 if(!$this->stmt->execute()) {
-                    return $this->failure("SQL Execution Error", $this->stmt->errno, $this->stmt->sqlstate, $this->stmt->error, $query);
+                    return StatementFailure::executing($this->stmt->errno, $this->stmt->sqlstate, $this->stmt->error, $query);
                 }
             } catch(\mysqli_sql_exception $error) {
-                return $this->failure("SQL Execution Error", (int) $error->getCode(), $this->sqlStateOf($error), $error->getMessage(), $query, $error);
+                return StatementFailure::executing((int) $error->getCode(), $this->sqlStateOf($error), $error->getMessage(), $query, $error);
             }
 
             return null;
-        }
-
-        /**
-         * Failure descriptor for one statement attempt, carrying what the
-         * recovery decision needs and the ready-to-throw exception with the
-         * historical prefix: "SQL Error" for connect and prepare failures,
-         * "SQL Execution Error" for execute failures.
-         */
-        private function failure(string $errorPrefix, int $errorCode, ?string $sqlState, string $message, string $query, ?\mysqli_sql_exception $error = null): array {
-            return [
-                "errorCode" => $errorCode,
-                "sqlState" => $sqlState,
-                "exception" => new \Exception($errorPrefix . ": " . $message . "\nQuery: " . $query, 0, $error),
-            ];
         }
 
         /**

--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -450,41 +450,45 @@
 
             // PHP 8.1+ defaults mysqli to STRICT reporting, which makes
             // multi_query() / next_result() throw mysqli_sql_exception instead
-            // of returning false / setting errno. Catch any of them and route
-            // back through the framework's throwOnFailure contract.
+            // of returning false / setting errno. Both reporting modes are
+            // routed through multiQueryFailed().
             try {
-                if($this->conn->multi_query($query) === false) {
-                    if($throwOnFailure) throw new \Exception("SQL Multi-Query Error: " . $this->conn->error . "\nQuery: " . $query);
-                    return false;
+                if(false === $this->conn->multi_query($query)) {
+                    return $this->multiQueryFailed($this->conn->error, $query, $throwOnFailure);
                 }
 
                 do {
-                    if($this->conn->errno) {
-                        if($throwOnFailure) throw new \Exception("SQL Multi-Query Error: " . $this->conn->error . "\nQuery: " . $query);
-
-                        while($this->conn->more_results()) $this->conn->next_result();
-                        return false;
-                    }
+                    if($this->conn->errno) return $this->multiQueryFailed($this->conn->error, $query, $throwOnFailure);
 
                     if($result = $this->conn->store_result()) $result->free();
                 } while($this->conn->more_results() && $this->conn->next_result());
 
-                if($this->conn->errno) {
-                    if($throwOnFailure) throw new \Exception("SQL Multi-Query Error: " . $this->conn->error . "\nQuery: " . $query);
-                    return false;
-                }
-            } catch(\mysqli_sql_exception $e) {
-                if($throwOnFailure) throw new \Exception("SQL Multi-Query Error: " . $e->getMessage() . "\nQuery: " . $query, 0, $e);
-                while($this->conn->more_results()) {
-                    try {
-                        $this->conn->next_result();
-                    } catch(\mysqli_sql_exception) {}
-                }
-                return false;
+                if($this->conn->errno) return $this->multiQueryFailed($this->conn->error, $query, $throwOnFailure);
+            } catch(\mysqli_sql_exception $error) {
+                return $this->multiQueryFailed($error->getMessage(), $query, $throwOnFailure, $error);
             }
 
             $this->lastHeartbeat = time();
             return true;
+        }
+
+        /**
+         * The single failure path of executeMultiQuery(), applying the
+         * framework's throwOnFailure contract. A swallowed failure drains the
+         * connection first, so the caller can keep using it.
+         */
+        private function multiQueryFailed(string $message, string $query, bool $throwOnFailure, ?\mysqli_sql_exception $error = null): bool {
+            if($throwOnFailure) throw new \Exception("SQL Multi-Query Error: " . $message . "\nQuery: " . $query, 0, $error);
+
+            // Discard the result sets still pending, which would otherwise
+            // fail the next statement with "commands out of sync". Draining
+            // stops at the first error: a connection that cannot be drained is
+            // replaced by assertConnection() on its next use.
+            try {
+                while($this->conn->more_results()) $this->conn->next_result();
+            } catch(\mysqli_sql_exception) {}
+
+            return false;
         }
 
         public function getDatabaseConnection(): \mysqli {

--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -90,21 +90,12 @@
                 'driver' => Mysql::class,
             ]);
 
-            // Check if timeout config is a valid number
-            $timeout = config("db_connection_timeout", default: 900);
-            if(!is_numeric($timeout)) {
-                throw new \InvalidArgumentException("Config key 'db_connection_timeout' must be numeric, got: '$timeout'");
-            }
-            $this->connectTimeout = (int) $timeout;
+            $this->connectTimeout = configNumeric("db_connection_timeout", 900);
 
             // Number of extra attempts made when a query fails with a transient,
             // cluster-related error (deadlock, lock-wait timeout, Galera
             // serialization conflict). 0 disables retries entirely.
-            $maxRetries = config("db_max_retries", default: 3);
-            if(!is_numeric($maxRetries)) {
-                throw new \InvalidArgumentException("Config key 'db_max_retries' must be numeric, got: '$maxRetries'");
-            }
-            $this->maxRetries = max(0, (int) $maxRetries);
+            $this->maxRetries = max(0, configNumeric("db_max_retries", 3));
 
             $this->user = config("dbusername");
             $this->password = config("dbpassword");

--- a/src/Database/StatementFailure.php
+++ b/src/Database/StatementFailure.php
@@ -1,0 +1,33 @@
+<?php
+
+    namespace ZubZet\Framework\Database;
+
+    /** One failed statement attempt: what execWithRecovery() classifies on, plus the exception to throw. */
+    class StatementFailure {
+
+        public \Exception $exception;
+
+        private function __construct(
+            string $prefix,
+            public int $errorCode,
+            public ?string $sqlState,
+            string $message,
+            string $query,
+            ?\mysqli_sql_exception $error,
+        ) {
+            $this->exception = new \Exception($prefix . ": " . $message . "\nQuery: " . $query, 0, $error);
+        }
+
+        /** Reaching the server or preparing the statement failed. */
+        public static function preparing(int $errorCode, ?string $sqlState, string $message, string $query, ?\mysqli_sql_exception $error = null): self {
+            return new self("SQL Error", $errorCode, $sqlState, $message, $query, $error);
+        }
+
+        /** Running the prepared statement failed. */
+        public static function executing(int $errorCode, ?string $sqlState, string $message, string $query, ?\mysqli_sql_exception $error = null): self {
+            return new self("SQL Execution Error", $errorCode, $sqlState, $message, $query, $error);
+        }
+
+    }
+
+?>

--- a/src/Support/GlobalReferences.php
+++ b/src/Support/GlobalReferences.php
@@ -78,6 +78,28 @@
             }
         });
 
+        FunctionConflictResolution::requireAndThen("configNumeric", function() {
+            /**
+             * Fetches a configuration value that has to be a number.
+             *
+             * Non-numeric values are rejected instead of cast, where a typo or
+             * a value like "off" would silently become 0 and disable whatever
+             * the setting controls.
+             *
+             * @param string $key Setting key
+             * @param int $default Value used when the key is missing
+             * @throws \InvalidArgumentException When the configured value is not numeric
+             * @return int Configured value as an integer
+             */
+            function configNumeric(string $key, int $default): int {
+                $value = config($key, default: $default);
+                if(!is_numeric($value)) {
+                    throw new \InvalidArgumentException("Config key '$key' must be numeric, got: '$value'");
+                }
+                return (int) $value;
+            }
+        });
+
         FunctionConflictResolution::requireAndThen("user", function() {
             /**
              * Proxy to the currently logged-in user's object


### PR DESCRIPTION
**Ready for review.** Technical notes live in `AGENTS.md`.

Makes the framework production-ready for Galera clusters behind a single database endpoint (a service mesh or load balancer), and makes the entire e2e suite run against a real three-node Galera cluster so every test exercises cluster behavior implicitly.

## Connection resilience (`Connection::exec()`)

Two failure classes are recovered, sharing the `db_max_retries` budget (default `3`, `0` disables):

- **Transient contention**: deadlock (`1213`), lock-wait timeout (`1205`), Galera serialization conflict (`40001`). The server already discarded the statement; it is re-prepared and re-run on the kept connection after a randomized 10-50 ms backoff.
- **Connection loss**: `1047`/`2002`/`2003`/`2006`/`2013`, the patterns a mesh produces when it moves the endpoint off a dead node, plus a Galera node refusing service while desynced as an SST/IST donor (with `wsrep_sync_wait`, donors answer every read with `1047` during any node rejoin, so this classification is what keeps rejoins invisible to clients). The connection is re-established through the same endpoint, the statement re-prepared and re-run. Backoff scales with the attempt (400 ms steps, 2 s cap) so the budget spans a realistic failover window. Each connect attempt is bounded by a 5 s timeout, and PHP 8.0 connect failures now throw the same exception type as PHP 8.1+.

Delivery semantics, documented in `AGENTS.md` and the changelog: re-running a statement whose acknowledgment was lost can apply a write twice in a narrow window. Every `exec()` is auto-committed, so the exposure is a single statement. Caller-managed raw-SQL transactions and `executeMultiQuery()` are deliberately not retried.

One operational finding worth knowing: a MySQL client waiting for the server greeting has **no read timeout**, so the endpoint in front of the cluster must close sessions to dead backends promptly. The e2e proxy config demonstrates the fail-fast settings; production meshes should behave equivalently.

## Code structure

The recovery loop is split into three single-purpose pieces: `execWithRecovery()` holds the retry policy with exactly one classification point (retry, reconnect, or throw), `attemptStatement()` makes one self-contained attempt (reconnect when asked, prepare, bind, execute), and a small failure descriptor carries the error code, the SQLSTATE read off the handle that recorded it, and the ready-to-throw exception. PHP 8.0 (mysqli failures by return value) and PHP 8.1+ (strict reporting throws) collapse into the same descriptor at the point of failure, so version differences never reach the policy. This restructuring also removed a hazard on PHP 8.0 where classifying a failed reconnect could read the SQLSTATE from an already-closed statement handle and mask the real error with a raised `Error`; equivalence of the rewrite was checked path by path against both reporting modes.

## Real Galera in the e2e stack

The single MariaDB container is replaced by a three-node Galera cluster (MariaDB 11.8, settings mirrored from the production infrastructure definition: `mariabackup` SST, `wsrep_retry_autocommit=3`, `innodb_autoinc_lock_mode=2`, enforced InnoDB) behind an haproxy registered as the `database` service, so the application configuration is unchanged. The proxy plays the mesh: one endpoint, round-robin across all healthy nodes (multi-writer, like production), sessions shut down on node death. One e2e-only setting on top of the mirrored production config: `wsrep_sync_wait = 1`, giving the suite deterministic read-your-writes when consecutive requests land on different nodes.

Notable implementation details:

- `galera1` bootstraps the cluster only on first initialization and rejoins on any later start (a restart with `--wsrep-new-cluster` would attempt a split bootstrap).
- The image's `healthcheck.sh` cannot be used on joiner nodes because SST replaces the datadir including the healthcheck credentials; the healthcheck asserts `wsrep_ready` instead, which also gates readiness on actual cluster membership.
- The stack always starts from empty volumes (`npm run stop` removes them), which keeps the bootstrap path safe.
- Field-tested by accident: the development host crashed hard (OOM) mid-session and the cluster reformed on its own after reboot via Galera's `pc.recovery`, no manual bootstrap needed.

## Test coverage

- `database/cluster.cy.js`: the suite runs against a synced three-node cluster; an application write is visible on every node.
- `database/failover.cy.js`: connections round-robin, so the probe publishes which node its connection landed on and the spec kills exactly that node mid-request, between two queries; the request completes on a surviving node (asserted via the connection provably moving nodes). The cluster degrades honestly and self-heals (restart policy plus join-aware bootstrap).
- `database/retry.cy.js`: both Galera lock-conflict semantics, fully deterministic: the probe opens its lock-holding connection RELATIVE to the node the framework connection landed on. Same node: lock-wait timeout, retried by `exec()` (timing proves it). Different node: Galera row locks are node-local, the write certifies instantly and the lock holder is brute-force aborted.
- The test application stays byte-identical with ordinary single-node user code: no fixture, controller, or model changed for the cluster. The e2e cluster sets `wsrep_auto_increment_control = OFF` (sequential requests then produce the same dense ids as a single node); production keeps the default, which interleaves ids by node offset, so applications should not build features that assume dense sequences, but nothing forces them to change.
- Flake tracking: headless runs retry a failing test once, the database is reseeded before any retry attempt (so no test has to be written retry-aware), and every test that only passed on a retry is recorded in `flaky-tests.log` and published as a CI artifact, so flakiness is measured instead of silently absorbed.
- Everything else in the suite runs on the cluster implicitly (747 tests green).

Probe tables use plain names (`test_retry`, `test_cluster`); the `z_` prefix stays reserved for framework tables.

## Open points

- Decided: retries stay default-on (`db_max_retries = 3`); apps that prefer failing over the rare double-apply set it to `0`.
- Retry logging/metrics (skipped so far to avoid the slow-query logger's checkpoint reentrancy).
- Multi-host `dbhost` lists as a later, additive feature for infrastructures without a mesh or load balancer.
- Unit tests for `isRetryable()` tracked in #180.

Closes #80

