### PR TITLE
feat(form): support multiple form actions in one view

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@ This is a simple changelog to keep track of things that have changed. It is not 
 These todos should be as temporary as possible:
 
 ## v1.4.0
+1. Added #183 - Multiple forms in one view: every `ZForm` submission carries a `formAction` taken from the new `name` option (falling back to `dom`), and `$req->hasFormData($formAction)` targets a single form. Argument-less calls keep detecting any submitted form
 1. Fixed `--dry` executing PHP migrations in `db:migrate` and `db:sync`. Migration files are no longer loaded during a dry run, so skip and environment markers are not evaluated - every pending migration is reported
 
 ## v1.2.0

--- a/src/Message/Request.php
+++ b/src/Message/Request.php
@@ -226,11 +226,15 @@
         }
 
         /**
-         * Checks if the request contains form data. When it contains form data, methods like validateForm() can be used.
+         * Checks if the request contains form data. When a form action is provided, it must match the submitted action.
+         * When it contains form data, methods like validateForm() can be used.
+         * @param string|null $formAction Optional action identifying one form among multiple forms
          * @return bool
          */
-        public function hasFormData(): bool {
-            return isset($this->input->POST["isFormData"]);
+        public function hasFormData(?string $formAction = null): bool {
+            if(!isset($this->input->POST["isFormData"])) return false;
+            if($formAction === null) return true;
+            return ($this->input->POST["formAction"] ?? null) === $formAction;
         }
 
         /**

--- a/tests/e2e/app/Controllers/MultipleFormController.php
+++ b/tests/e2e/app/Controllers/MultipleFormController.php
@@ -1,0 +1,80 @@
+<?php
+
+    class MultipleFormController extends z_controller {
+
+        public function action_multiple(Request $req, Response $res) {
+            if($req->hasFormData("billing")) {
+                $formResult = $req->validateForm([
+                    (new FormField("billing_value"))
+                        ->required(),
+                ]);
+
+                if($formResult->hasErrors) {
+                    return $res->formErrors($formResult->errors);
+                }
+
+                return $res->success([
+                    "form" => "billing",
+                    "billing_value" => $req->getPost("billing_value"),
+                    "shipping_value" => $req->getPost("shipping_value"),
+                ]);
+            }
+
+            if($req->hasFormData("shipping")) {
+                $formResult = $req->validateForm([
+                    (new FormField("shipping_value")),
+                ]);
+
+                if($formResult->hasErrors) {
+                    return $res->formErrors($formResult->errors);
+                }
+
+                return $res->success([
+                    "form" => "shipping",
+                    "billing_value" => $req->getPost("billing_value"),
+                    "shipping_value" => $req->getPost("shipping_value"),
+                ]);
+            }
+
+            return $res->render("multipleForm/multiple");
+        }
+
+        public function action_named(Request $req, Response $res) {
+            if($req->hasFormData("named-action")) {
+                return $res->success([
+                    "formAction" => $req->getPost("formAction"),
+                ]);
+            }
+
+            return $res->render("multipleForm/named");
+        }
+
+        public function action_domFallback(Request $req, Response $res) {
+            if($req->hasFormData("fallback-form")) {
+                return $res->success([
+                    "formAction" => $req->getPost("formAction"),
+                ]);
+            }
+
+            return $res->render("multipleForm/domFallback");
+        }
+
+        public function action_unnamed(Request $req, Response $res) {
+            if($req->hasFormData()) {
+                return $res->success([
+                    "formAction" => $req->getPost("formAction"),
+                ]);
+            }
+
+            return $res->render("multipleForm/unnamed");
+        }
+
+        public function action_probe(Request $req, Response $res) {
+            return $res->json([
+                "any" => $req->hasFormData(),
+                "named" => $req->hasFormData("target-action"),
+            ]);
+        }
+
+    }
+?>

--- a/tests/e2e/app/Views/multipleForm/domFallback.php
+++ b/tests/e2e/app/Views/multipleForm/domFallback.php
@@ -1,0 +1,14 @@
+<?php return [ "body" => function($opt) { ?>
+    <div id="fallback-form" data-test="form"></div>
+
+    <script>
+        var form = Z.Forms.create({
+            dom: "fallback-form",
+        });
+
+        form.createField({
+            name: "fallback_value",
+            type: "text",
+        });
+    </script>
+<?php }]; ?>

--- a/tests/e2e/app/Views/multipleForm/multiple.php
+++ b/tests/e2e/app/Views/multipleForm/multiple.php
@@ -1,0 +1,26 @@
+<?php return [ "body" => function($opt) { ?>
+    <div id="billing-form" data-test="billing-form"></div>
+    <div id="shipping-form" data-test="shipping-form"></div>
+
+    <script>
+        var billingForm = Z.Forms.create({
+            dom: "billing-form",
+            name: "billing",
+        });
+
+        billingForm.createField({
+            name: "billing_value",
+            type: "text",
+        });
+
+        var shippingForm = Z.Forms.create({
+            dom: "shipping-form",
+            name: "shipping",
+        });
+
+        shippingForm.createField({
+            name: "shipping_value",
+            type: "text",
+        });
+    </script>
+<?php }]; ?>

--- a/tests/e2e/app/Views/multipleForm/named.php
+++ b/tests/e2e/app/Views/multipleForm/named.php
@@ -1,0 +1,15 @@
+<?php return [ "body" => function($opt) { ?>
+    <div id="named-form" data-test="form"></div>
+
+    <script>
+        var form = Z.Forms.create({
+            dom: "named-form",
+            name: "named-action",
+        });
+
+        form.createField({
+            name: "named_value",
+            type: "text",
+        });
+    </script>
+<?php }]; ?>

--- a/tests/e2e/app/Views/multipleForm/unnamed.php
+++ b/tests/e2e/app/Views/multipleForm/unnamed.php
@@ -1,0 +1,13 @@
+<?php return [ "body" => function($opt) { ?>
+    <div data-test="form"></div>
+
+    <script>
+        var form = Z.Forms.create({});
+        document.querySelector("[data-test=form]").appendChild(form.dom);
+
+        form.createField({
+            name: "unnamed_value",
+            type: "text",
+        });
+    </script>
+<?php }]; ?>

--- a/tests/e2e/tests/cypress/e2e/form/multiple-form.cy.js
+++ b/tests/e2e/tests/cypress/e2e/form/multiple-form.cy.js
@@ -1,0 +1,138 @@
+describe('Multiple Forms', () => {
+    before(() => {
+        cy.dbSeed();
+    });
+
+    describe('two forms in one view', () => {
+        beforeEach(() => {
+            cy.intercept('POST', '/MultipleForm/multiple').as('submit');
+            cy.visit('/MultipleForm/multiple');
+        });
+
+        it('routes the billing submit to the billing branch only', () => {
+            cy.form('billing_value').type('invoice address');
+            cy.form('shipping_value').type('delivery address');
+            cy.query('billing-form').find('button').click();
+
+            cy.wait('@submit').then((interception) => {
+                const json = JSON.parse(interception.response.body);
+                expect(json.result).to.eq('success');
+                expect(json.form).to.eq('billing');
+                expect(json.billing_value).to.eq('invoice address');
+                expect(json.shipping_value).to.be.null;
+            });
+
+            cy.query('billing-form').contains('Saved!');
+            cy.query('shipping-form').should('not.contain.text', 'Saved!');
+        });
+
+        it('routes the shipping submit to the shipping branch only', () => {
+            cy.form('billing_value').type('invoice address');
+            cy.form('shipping_value').type('delivery address');
+            cy.query('shipping-form').find('button').click();
+
+            cy.wait('@submit').then((interception) => {
+                const json = JSON.parse(interception.response.body);
+                expect(json.result).to.eq('success');
+                expect(json.form).to.eq('shipping');
+                expect(json.shipping_value).to.eq('delivery address');
+                expect(json.billing_value).to.be.null;
+            });
+
+            cy.query('shipping-form').contains('Saved!');
+            cy.query('billing-form').should('not.contain.text', 'Saved!');
+        });
+
+        it('shows validation errors only on the submitted form', () => {
+            cy.query('billing-form').find('button').click();
+
+            cy.wait('@submit').then((interception) => {
+                const json = JSON.parse(interception.response.body);
+                expect(json.result).to.eq('formErrors');
+            });
+
+            cy.form('billing_value').parent().contains('Please fill in this field');
+            cy.query('shipping-form').should('not.contain.text', 'Please fill in this field');
+        });
+    });
+
+    describe('formAction sent by Z.Forms', () => {
+        it('uses the explicit name option, overriding the dom id', () => {
+            cy.intercept('POST', '/MultipleForm/named').as('submit');
+            cy.visit('/MultipleForm/named');
+
+            cy.form('named_value').type('named payload');
+            cy.query('form').find('button').click();
+
+            cy.wait('@submit').then((interception) => {
+                const json = JSON.parse(interception.response.body);
+                expect(json.result).to.eq('success');
+                expect(json.formAction).to.eq('named-action');
+            });
+            cy.query('form').contains('Saved!');
+        });
+
+        it('falls back to the dom id when no name is configured', () => {
+            cy.intercept('POST', '/MultipleForm/domFallback').as('submit');
+            cy.visit('/MultipleForm/domFallback');
+
+            cy.form('fallback_value').type('fallback payload');
+            cy.query('form').find('button').click();
+
+            cy.wait('@submit').then((interception) => {
+                const json = JSON.parse(interception.response.body);
+                expect(json.result).to.eq('success');
+                expect(json.formAction).to.eq('fallback-form');
+            });
+            cy.query('form').contains('Saved!');
+        });
+
+        it('sends no formAction when neither name nor dom is set', () => {
+            cy.intercept('POST', '/MultipleForm/unnamed').as('submit');
+            cy.visit('/MultipleForm/unnamed');
+
+            cy.form('unnamed_value').type('legacy payload');
+            cy.query('form').find('button').click();
+
+            cy.wait('@submit').then((interception) => {
+                const json = JSON.parse(interception.response.body);
+                expect(json.result).to.eq('success');
+                expect(json.formAction).to.be.null;
+            });
+            cy.query('form').contains('Saved!');
+        });
+    });
+
+    describe('hasFormData() matching rules', () => {
+        const probe = (body) => cy.request({
+            method: 'POST',
+            url: '/MultipleForm/probe',
+            form: true,
+            body,
+        });
+
+        it('matches any form submission when called without an action', () => {
+            probe({ isFormData: 1 }).then((res) => {
+                expect(res.body).to.deep.eq({ any: true, named: false });
+            });
+        });
+
+        it('matches a named action only on the exact formAction', () => {
+            probe({ isFormData: 1, formAction: 'target-action' }).then((res) => {
+                expect(res.body).to.deep.eq({ any: true, named: true });
+            });
+        });
+
+        it('does not match a named action on a different formAction', () => {
+            probe({ isFormData: 1, formAction: 'other-action' }).then((res) => {
+                expect(res.body).to.deep.eq({ any: true, named: false });
+            });
+        });
+
+        it('is no form data without the isFormData flag, even with a formAction', () => {
+            probe({ formAction: 'target-action' }).then((res) => {
+                expect(res.body).to.deep.eq({ any: false, named: false });
+            });
+        });
+    });
+});

--- a/web/Z.js
+++ b/web/Z.js
@@ -700,6 +700,7 @@ class ZForm {
    * @param {object} options Options
    * @param {boolean} [options.doReload] Should the form reload after submit? This is automatically set to true when using a CED in the form
    * @param {string} [options.dom] Id of a dom element to append this form automatically to
+   * @param {string} [options.name] Action name sent to the backend. Falls back to `dom` when omitted.
    * @param {saveHook} [options.saveHook] Function that is called after saving. It is only called after a success and not when validation errors occour
    * @param {formErrorHook} [options.formErrorHook] Function that is only called on form errors
    * @param {boolean} [options.hidehints] Suppress the inline hint banner (saved / unsaved / error). Defaults to `false` (hints are shown).
@@ -715,12 +716,14 @@ class ZForm {
     formErrorHook:null,
     hidehints: false,
     sendOnSubmitClick: true,
-    customEndpoint: null
+    customEndpoint: null,
+    name: null,
   }) {
     this.fields = {};
     this.options = options;
     this.ceds = [];
 
+    this.formAction = options.name || options.dom || null;
     this.doReload = options.doReload || false;
     this.saveHook = options.saveHook;
     this.formErrorHook = options.formErrorHook;
@@ -883,6 +886,10 @@ class ZForm {
 
     for (var pair of data.entries()) {
       if(this.debug) console.log(pair[0]+ ', ' + pair[1]); 
+    }
+
+    if(this.formAction) {
+        data.set("formAction", this.formAction);
     }
 
     var ajax_options = {


### PR DESCRIPTION
## Summary

This experimental feature adds form actions, allowing multiple forms on the same view to be identified and handled independently.

Define an action when creating a form:

```js
const commentForm = Z.Forms.create({
    dom: "comment-form",
    name: "comment",
});
```

The action is submitted as part of the form data and can be checked in the controller:

```php
if($req->hasFormData("comment")) {
    // Handle the comment form.
}
```

Calling `$req->hasFormData()` without an action continues to detect any submitted ZubZet form, preserving the existing behavior.