### PR TITLE
feat(health): add optional /_zubzet/health endpoint with database check

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,7 @@ These todos should be as temporary as possible:
 
 ## v1.4.0
 1. Added #183 - Multiple forms in one view: every `ZForm` submission carries a `formAction` taken from the new `name` option (falling back to `dom`), and `$req->hasFormData($formAction)` targets a single form. Argument-less calls keep detecting any submitted form
+1. Added #178 - Health endpoint at `GET /_zubzet/health`: performs an explicit database check and reports plain JSON without error details. Enabled by default, disable via `health_endpoint_enabled = false`
 1. Fixed `--dry` executing PHP migrations in `db:migrate` and `db:sync`. Migration files are no longer loaded during a dry run, so skip and environment markers are not evaluated - every pending migration is reported
 
 ## v1.2.0

--- a/docs/core-features/health-endpoint.md
+++ b/docs/core-features/health-endpoint.md
@@ -1,0 +1,23 @@
+# Health Endpoint
+Since version **1.4.0**, the framework ships a public health check:
+
+```
+GET /_zubzet/health
+```
+
+It performs an explicit database roundtrip (`SELECT 1`) and reports the result as JSON. The response never contains error details, so the endpoint is safe to expose publicly for uptime monitoring, downtime alerts, and readiness checks during application startup.
+
+## Responses
+| Condition | Status | Body |
+| --------- | ------ | ---- |
+| Application and database reachable | `200` | `{"status": "healthy"}` |
+| Database unreachable | `503` | `{"status": "unhealthy"}` |
+
+## Disabling
+The endpoint is enabled by default. Turn it off in `z_settings.ini`:
+
+```ini
+health_endpoint_enabled = false
+```
+
+When disabled, the route is not registered and `/_zubzet/health` answers `404`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -130,6 +130,7 @@ nav:
         - Error Handling: core-features/error-handling
         - Asset Proxy: core-features/asset-proxy
         - Maintenance: core-features/maintenance
+        - Health Endpoint: core-features/health-endpoint
     - Admin Dashboard:
         - Genral Usage: z-admin/usage
         - Login as another User: z-admin/login-as-another-user

--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -361,7 +361,11 @@
          */
         public function disconnect() {
             if(!isset($this->conn)) return;
-            $this->conn->close();
+
+            try {
+                $this->conn->close();
+            } catch(\Throwable) {}
+            unset($this->conn);
         }
 
         /**

--- a/src/IncludedComponents/controllers/ZubZetController.php
+++ b/src/IncludedComponents/controllers/ZubZetController.php
@@ -1,0 +1,22 @@
+<?php
+
+    class ZubZetController {
+
+        public function health(Request $req, Response $res) {
+            // The buffer discards connection warnings PHP 8.0 emits instead of throwing
+            ob_start();
+            try {
+                db()->exec("SELECT 1");
+                $healthy = true;
+            } catch(\Throwable) {
+                $healthy = false;
+            }
+            ob_end_clean();
+
+            if(!$healthy) http_response_code(503);
+            return $res->json(["status" => $healthy ? "healthy" : "unhealthy"]);
+        }
+
+    }
+
+?>

--- a/src/IncludedComponents/routes/DefaultRoutes.php
+++ b/src/IncludedComponents/routes/DefaultRoutes.php
@@ -5,5 +5,9 @@
         Route::get('/asset-proxy/{assetPath:.+}', function(array $args) {
             zubzet()->assetProxy->serve($args['assetPath']);
         });
+
+        if(config("health_endpoint_enabled", default: true)) {
+            Route::get('/health', [ZubZetController::class, 'health']);
+        }
     });
 ?>

--- a/tests/e2e/tests/cypress/e2e/core/health-endpoint.cy.js
+++ b/tests/e2e/tests/cypress/e2e/core/health-endpoint.cy.js
@@ -1,0 +1,89 @@
+describe('Health Endpoint', () => {
+
+    before(() => cy.saveConfigBackup());
+
+    after(() => cy.restoreConfigBackup());
+
+    const waitForDatabase = (attempt = 0) => {
+        cy.exec('docker exec database healthcheck.sh --connect', {
+            failOnNonZeroExit: false,
+        }).then((result) => {
+            if(result.exitCode === 0) return;
+            expect(attempt, 'database did not come back in time').to.be.lessThan(60);
+            cy.wait(1000);
+            waitForDatabase(attempt + 1);
+        });
+    };
+
+    describe('Enabled', () => {
+
+        before(() => cy.setConfigSetting('health_endpoint_enabled', 'true'));
+
+        it('should report a healthy application as JSON', () => {
+            cy.request({
+                method: 'GET',
+                url: '/_zubzet/health',
+                failOnStatusCode: false,
+            }).then((res) => {
+                expect(res.status).to.equal(200);
+                expect(res.body).to.deep.equal({ status: 'healthy' });
+            });
+        });
+    });
+
+    describe('Database Unavailable', () => {
+
+        before(() => {
+            cy.setConfigSetting('health_endpoint_enabled', 'true');
+            cy.exec('docker stop database');
+        });
+
+        after(() => {
+            cy.exec('docker start database');
+            waitForDatabase();
+        });
+
+        it('should report unhealthy without exposing error details', () => {
+            cy.request({
+                method: 'GET',
+                url: '/_zubzet/health',
+                failOnStatusCode: false,
+            }).then((res) => {
+                expect(res.status).to.equal(503);
+                expect(res.body).to.deep.equal({ status: 'unhealthy' });
+            });
+        });
+
+        it('should recover once the database is back', () => {
+            cy.exec('docker start database');
+            waitForDatabase();
+
+            cy.request({
+                method: 'GET',
+                url: '/_zubzet/health',
+            }).then((res) => {
+                expect(res.status).to.equal(200);
+                expect(res.body).to.deep.equal({ status: 'healthy' });
+            });
+        });
+
+    });
+
+    describe('Disabled', () => {
+
+        before(() => cy.setConfigSetting('health_endpoint_enabled', 'false'));
+
+        after(() => cy.setConfigSetting('health_endpoint_enabled', 'true'));
+
+        it('should return 404 when turned off', () => {
+            cy.request({
+                method: 'GET',
+                url: '/_zubzet/health',
+                failOnStatusCode: false,
+            }).then((res) => {
+                expect(res.status).to.equal(404);
+            });
+        });
+    });
+
+});

--- a/tests/e2e/z_config/z_settings.ini
+++ b/tests/e2e/z_config/z_settings.ini
@@ -40,4 +40,6 @@ development_editor = vscode
 
 maintenance_mode = off
 
+health_endpoint_enabled = true
+
 debugbar_hide_internal_queries = true


### PR DESCRIPTION
Implements a framework-provided health check

# Usage:
GET /_zubzet/health

| Condition | Status | Body |
| --------- | ------ | ---- |
| Application and database reachable | `200` | `{"status": "healthy"}` |
| Database unreachable | `503` | `{"status": "unhealthy"}` |

The action performs an explicit database roundtrip (`SELECT 1`) and reports the result as JSON. The response never contains error details, so the endpoint is safe to expose publicly.

# Configuration:
Enabled by default. 
Projects can opt out via `z_settings.ini`:

    health_endpoint_enabled = false

When disabled, the route is not registered and `/_zubzet/health` answers `404`.

Closes #178