### PR TITLE
ci(docs): promote only stable tags to latest, point edge at every tag

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,6 +19,11 @@ on:
         required: true
         type: boolean
         default: false
+      update_edge:
+        description: 'Also update "edge" alias (newest tag of any kind)?'
+        required: true
+        type: boolean
+        default: false
 
 jobs:
   build-docs:
@@ -80,14 +85,21 @@ jobs:
               echo "REF_NAME=${{ inputs.ref }}" >> $GITHUB_ENV
             fi
             echo "PROMOTE=${{ inputs.promote_latest }}" >> $GITHUB_ENV
+            echo "UPDATE_EDGE=${{ inputs.update_edge }}" >> $GITHUB_ENV
           else
             echo "REF_TYPE=${{ github.ref_type }}" >> $GITHUB_ENV
             echo "REF_NAME=${{ github.ref_name }}" >> $GITHUB_ENV
-            # For normal tag pushes we DO promote latest
             if [ "${{ github.ref_type }}" = "tag" ]; then
-              echo "PROMOTE=true" >> $GITHUB_ENV
+              # Every freshly pushed tag is the newest one -> it takes 'edge'.
+              echo "UPDATE_EDGE=true" >> $GITHUB_ENV
+              # Only stable tags (no -RCn / -alphaN suffix) take 'latest' + default.
+              case "${{ github.ref_name }}" in
+                *-*) echo "PROMOTE=false" >> $GITHUB_ENV ;;
+                *)   echo "PROMOTE=true"  >> $GITHUB_ENV ;;
+              esac
             else
               echo "PROMOTE=false" >> $GITHUB_ENV
+              echo "UPDATE_EDGE=false" >> $GITHUB_ENV
             fi
           fi
 
@@ -97,14 +109,19 @@ jobs:
 
           if [ "$REF_TYPE" = "tag" ]; then
             version="$REF_NAME" # e.g. v0.11.0
-            if [ "$PROMOTE" = "true" ]; then
-              mike deploy --update-aliases "$version" latest \
-                --deploy-prefix docs -b gh-pages -r website -p
-              mike set-default latest \
+            aliases=""
+            if [ "$PROMOTE" = "true" ]; then aliases="$aliases latest"; fi
+            if [ "$UPDATE_EDGE" = "true" ]; then aliases="$aliases edge"; fi
+            if [ -n "$aliases" ]; then
+              mike deploy --update-aliases "$version" $aliases \
                 --deploy-prefix docs -b gh-pages -r website -p
             else
-              # just publish the old version without changing 'latest'
+              # just publish the version without touching any alias
               mike deploy "$version" \
+                --deploy-prefix docs -b gh-pages -r website -p
+            fi
+            if [ "$PROMOTE" = "true" ]; then
+              mike set-default latest \
                 --deploy-prefix docs -b gh-pages -r website -p
             fi
           else


### PR DESCRIPTION
Pre-release tags (`-RCn`, `-alphaN`) matched the `v*.*.*` trigger and unconditionally took the `latest` alias plus the site default, which is how `v1.3.0-alpha1` stole the docs default from `v1.2.0`.

- Tag pushes now only promote `latest`/default for stable tags (no hyphen suffix).
- Every tag push points the new `edge` alias at itself, so `edge` is always the newest tag of any kind (pre-releases included) and can never lag `latest`.
- New `update_edge` dispatch input mirrors `promote_latest` for manual repairs/backfills; plain re-deploys of old versions touch no alias.

The stolen default has already been repaired via dispatch (`ref=v1.2.0`, `promote_latest=true`). After this merges, `edge` can be backfilled with `ref=v1.3.0-alpha1`, `update_edge=true`. The matching how-to-release.md wording update lands with the ongoing docs pass.

https://claude.ai/code/session_01Jmsj4Yw5NuWU7smxjpYbUS