### PR TITLE
Docs unification

### DIFF
--- a/docs/advanced-features/aliases-and-virtual-links.md
+++ b/docs/advanced-features/aliases-and-virtual-links.md
@@ -1,6 +1,6 @@
 # Using aliases within virtual links
 ## Explanation
-If would like to have short or  other versions of your virtual links, you can use aliases. To create a new alias, use the reroute method.  More about the reroute method can be found in the API reference. Set the second parameter to true. This turns the reroute into an alias reroute. The current path will then be replaced with the first argument, but will not be truncated.
+If would like to have short or  other versions of your [virtual links](../core-features/parameter-abstraction.md), you can use aliases. To create a new alias, use the reroute method.  More about the reroute method can be found in the [API reference](../api/classes/ZubZet-Framework-Message-Response.html#method_reroute). Set the second parameter to true. This turns the reroute into an alias reroute. The current path will then be replaced with the first argument, but will not be truncated.
 
 ## Example
 Only the first part of the URL get rerouted. The rest stays untouched.

--- a/docs/advanced-features/commands.md
+++ b/docs/advanced-features/commands.md
@@ -1,5 +1,5 @@
 ## Creating a command
-The current implementation simply uses the already existing controller structure. Nothing extra needed to do.
+The current implementation simply uses the already existing [controller structure](../core-features/controllers-and-actions.md). Nothing extra needed to do.
 
 ## Running a command
 To run a command, simply use: `php index.php run <controller> <action> <param1> ...` 

--- a/docs/core-features/access-control.md
+++ b/docs/core-features/access-control.md
@@ -4,13 +4,13 @@ ZubZet now includes significantly enhanced **access control and permission capab
 The system is built to provide a **flexible and extensible authorization workflow**, improved **developer ergonomics**, and full support for **user-based and role-based permissions**.
 
 At its core, the access control system introduces two primary domain objects: **User** and **Role**.
-Permissions can be assigned directly to users or indirectly through roles. All permission checks automatically resolve the **combined permission set**.
+[Permissions](permission-system.md) can be assigned directly to users or indirectly through roles. All permission checks automatically resolve the **combined permission set**.
 
 ---
 
 ## User Object
 
-The `User` object represents an application user and exposes a comprehensive API for retrieval, lifecycle management, and permission handling.
+The [`User`](../api/classes/ZubZet-Framework-Authentication-Permission-User.html) object represents an application user and exposes a comprehensive API for retrieval, lifecycle management, and permission handling.
 
 ### User Retrieval
 
@@ -112,7 +112,7 @@ User attributes can be updated directly on the instance.
     $user->updateEmail(?string $email);
     ```
 
-* Updates the user’s password.
+* Updates the user’s [password](password-handling.md).
 
     ```php
     $user->updatePassword(string $password);
@@ -295,7 +295,7 @@ Permission checks always resolve the **complete permission set**.
 
 ## Role Object
 
-The `Role` object represents a named collection of permissions that can be assigned to users.
+The [`Role`](../api/classes/ZubZet-Framework-Authentication-Permission-Role.html) object represents a named collection of permissions that can be assigned to users.
 
 ### Role Retrieval
 
@@ -459,7 +459,7 @@ The `Role` object represents a named collection of permissions that can be assig
 
 ## Organization Object
 
-The `Organization` object represents a group of users. Users can belong to at most one organization. An organization has a name (not unique) and is soft-deletable like the other authentication objects.
+The [`Organization`](../api/classes/ZubZet-Framework-Authentication-Organization.html) object represents a group of users. Users can belong to at most one organization. An organization has a name (not unique) and is soft-deletable like the other authentication objects.
 
 ### Organization Retrieval
 
@@ -559,7 +559,7 @@ The `Organization` object represents a group of users. Users can belong to at mo
 
 ## Session Object
 
-The `Session` object represents a login session (stored in `z_logintoken`) and provides methods for creation, retrieval, lifetime management, and invalidation.
+The [`Session`](../api/classes/ZubZet-Framework-Authentication-Session.html) object represents a login session (stored in `z_logintoken`) and provides methods for creation, retrieval, lifetime management, and invalidation.
 
 ### Session Retrieval
 

--- a/docs/core-features/asset-proxy.md
+++ b/docs/core-features/asset-proxy.md
@@ -1,7 +1,7 @@
 # Asset Proxy
 
 Since version **1.2.0**, ZubZet serves CSS, JavaScript, fonts, and other static assets through an
-**asset proxy** instead of exposing them as files in your web root. A single internal route resolves
+**[asset proxy](../api/classes/ZubZet-Framework-Resources-AssetProxy.html)** instead of exposing them as files in your web root. A single internal route resolves
 each request against a list of registered source directories, which means framework- and
 package-bundled assets no longer have to be copied into every project.
 
@@ -18,7 +18,7 @@ first registered source that contains it.
 
 ## Referencing assets in views
 
-Use the `generateResourceLink` helper available on every view's `$opt` array — it builds a correct,
+Use the `generateResourceLink` helper available on every [view's](views.md) `$opt` array — it builds a correct,
 root-relative URL for you:
 
 ```blade
@@ -51,7 +51,7 @@ packages — no files are copied into your project.
 ## Registering your own source
 
 To expose an additional directory (for example, assets shipped by one of your own Composer packages),
-register it on the proxy with an absolute path and an optional URL prefix:
+[register it on the proxy](../api/classes/ZubZet-Framework-Resources-AssetProxy.html#method_registerWebRootSource) with an absolute path and an optional URL prefix:
 
 ```php
 zubzet()->assetProxy->registerWebRootSource("/var/www/vendor/acme/ui-kit/dist", "ui-kit");
@@ -69,5 +69,5 @@ The proxy is designed to serve only files that live inside a registered source:
   result stays within the registered source directory, so `../` sequences and symlink escapes cannot
   reach files outside the mount.
 - **Only readable, existing files are served**; anything else returns `404`.
-- **Content types are detected** with `league/mime-type-detection`, falling back to
+- **[Content types are detected](https://github.com/thephpleague/mime-type-detection)** with `league/mime-type-detection`, falling back to
   `application/octet-stream` when the type is unknown.

--- a/docs/core-features/configuration.md
+++ b/docs/core-features/configuration.md
@@ -4,7 +4,7 @@
 The booter settings are a way of getting your most basic settings. If you have something like the uploads folder or the database connection, that might be changed by a customer/admin after finishing this project, those values can be stored under your `z_config folder` as a key of `z_settings.ini`.
 
 ## How to use it
-If you want to use another key, simply create a new key in your `z_settings.ini`. To recall the value use `$res->getBooterSettings("key")`. If you don't pass a key, the whole array of values will be returned.
+If you want to use another key, simply create a new key in your `z_settings.ini`. To [recall the value](../api/classes/ZubZet-Framework-Core-CanRetrieveBooterSettings.html#method_getBooterSettings) use `$res->getBooterSettings("key")`. If you don't pass a key, the whole array of values will be returned.
 
 ## What do you actually put in here?
 - Database connection details

--- a/docs/core-features/console-commands.md
+++ b/docs/core-features/console-commands.md
@@ -5,7 +5,7 @@ Console commands enable automation, debugging, and execution of application logi
 
 ### How to Run a Command
 
-To execute a console command inside the Docker container, first access the container shell:
+To execute a console command inside the [Docker container](../setup/installation.md), first access the container shell:
 
 ```bash
 npm run shell
@@ -34,8 +34,8 @@ Lists all available console commands.
 
 ### run
 
-Executes a controller action directly from the console environment.
-This is useful for running application logic, maintenance tasks, or background operations without an HTTP request.
+Executes a [controller action](controllers-and-actions.md) directly from the console environment.
+This is useful for [running application logic](../advanced-features/commands.md), maintenance tasks, or background operations without an HTTP request.
 
 ### info:startup
 

--- a/docs/core-features/controllers-and-actions.md
+++ b/docs/core-features/controllers-and-actions.md
@@ -1,7 +1,7 @@
 # Getting Started: Controllers and Actions
 
 ## What does a controller do?
-A controller is one part of the MVC pattern. It handles all the logic, but what does that mean? Usually the controller takes in data from one or multiple models as well as user input and does something with it. This could include sorting, searching, calculating and generally making the data ready to display or ready to put into the database in case of a form input for example. 
+A controller is one part of the [MVC pattern](mvc.md). It handles all the logic, but what does that mean? Usually the controller takes in data from one or multiple [models](models.md) as well as user input and does something with it. This could include sorting, searching, calculating and generally making the data ready to display or ready to put into the database in case of a form input for example. 
 
 ## How to get a controller executed?
 Since there are no actual paths, controllers are tightly bound to the requested url. The first part of the URL, that is not part of getting to your project's root directory, determines which Controller will be used. If you call your controller IndexController, it will be executed when no name is given by a reuqest. 
@@ -100,3 +100,11 @@ The following function `action_test` will be executed when requesting the path `
     }
 ?>
 ```
+
+## See also
+
+- [Routing](routing.md): registering explicit route definitions instead of name-based routing
+- [Views](views.md): the templates rendered by `$res->render`
+- [Permission System](permission-system.md): the permissions behind `$req->checkPermission`
+- [Parameter Abstraction](parameter-abstraction.md): reading URL parameters and POST data
+- API reference: [Request](../api/classes/ZubZet-Framework-Message-Request.html) and [Response](../api/classes/ZubZet-Framework-Message-Response.html)

--- a/docs/core-features/debug-bar.md
+++ b/docs/core-features/debug-bar.md
@@ -16,7 +16,7 @@ execution_type = test
 
 If `execution_type` is anything other than `test` (including unset), the bar is not bootstrapped, no assets are emitted, and no collectors run. There is no way to enable it for production.
 
-The bar relies on the layout calling the body essentials. The default layout already does this. If you ship a custom layout and want the bar visible there too, include the body essentials inside your `<body>`:
+The bar relies on the [layout](layouts.md) calling the body essentials. The default layout already does this. If you ship a custom layout and want the bar visible there too, include the body essentials inside your `<body>`:
 
 ```blade
 <x-zubzet::body :opt="$opt"/>
@@ -26,7 +26,7 @@ The bar relies on the layout calling the body essentials. The default layout alr
 
 ### Queries
 
-Every SQL statement that runs through `Connection::exec()` (or `Model::exec()`) is captured with its placeholders interpolated, the bound values, the duration, and the row count. Click a query to open a parameter table and copy the statement to the clipboard.
+Every SQL statement that [runs through](../api/classes/ZubZet-Framework-Database-Connection.html#method_exec) `Connection::exec()` (or `Model::exec()`) is captured with its placeholders interpolated, the bound values, the duration, and the row count. Click a query to open a parameter table and copy the statement to the clipboard.
 
 Bound values are rendered as single quoted SQL literals so the displayed query can be pasted into a SQL client and executed as is.
 
@@ -37,7 +37,7 @@ VALUES ('TestData')
 
 ### Templates
 
-Every view passed to `$res->render(...)` is captured as a row in the templates tab, together with the layout name and the original options array.
+Every [view](views.md) passed to `$res->render(...)` is captured as a row in the templates tab, together with the layout name and the original options array.
 
 ```
 core/render (layout: layout/default_layout.php)
@@ -70,7 +70,7 @@ Set it to `false` to see every query, including the ones the framework runs inte
 
 ## Marking your own models as internal
 
-If you have models that you consider infrastructure rather than application logic, you can opt them into the same filter. Use the `IsInternalModel` trait on the model class:
+If you have [models](models.md) that you consider infrastructure rather than application logic, you can opt them into the same filter. Use the `IsInternalModel` [trait](../api/classes/ZubZet-Framework-Database-IsInternalModel.html) on the model class:
 
 ```php
 use ZubZet\Framework\Database\IsInternalModel;

--- a/docs/core-features/error-handling.md
+++ b/docs/core-features/error-handling.md
@@ -37,7 +37,7 @@ this:
 
 ### Sensitive data masking
 
-Whoops automatically masks request values whose keys look sensitive (containing `pass`, `secret`,
+Whoops automatically [masks request values](../api/classes/ZubZet-Framework-ErrorHandling-WhoopsHandler.html) whose keys look sensitive (containing `pass`, `secret`,
 `token`, `session`, `auth`, `key`, `credential`, …) across `$_GET`, `$_POST`, `$_COOKIE`,
 `$_SESSION`, `$_SERVER`, and `$_ENV`, so credentials are not printed on the error page.
 

--- a/docs/core-features/global-helper-functions.md
+++ b/docs/core-features/global-helper-functions.md
@@ -156,3 +156,19 @@ Renders a [view template](views.md) directly.
 view("adminpanel/dashboard");
 
 ```
+
+### `e()`
+
+Escapes a string for safe HTML output. It strips tags and then escapes the remaining special characters through the render engine, so its output matches what `{{ }}` produces in a [view](views.md).
+
+**Syntax:** `e(?string $value): ?string`
+
+* **$value**: The string to escape. `null` is passed through unchanged, so optional values can be escaped without an extra check.
+
+Use it whenever a value ends up in HTML outside of a template echo, for example in attributes built in PHP.
+
+**Example:**
+
+```php
+<a title="<?= e($opt["title"]) ?>">
+```

--- a/docs/core-features/global-helper-functions.md
+++ b/docs/core-features/global-helper-functions.md
@@ -6,7 +6,7 @@ To optimize developer experience and eliminate redundant boilerplate, **global h
 
 ### `zubzet()`
 
-Returns the main instance of the ZubZet framework.
+Returns the [main instance](../api/classes/ZubZet-Framework-ZubZet.html) of the ZubZet framework.
 
 **Syntax:** `zubzet()`
 
@@ -14,7 +14,7 @@ Returns the main instance of the ZubZet framework.
 
 ### `model()`
 
-Provides direct access to a specific model instance.
+Provides direct access to a specific [model](models.md) instance.
 
 **Syntax:** `model(string $modelName)`
 
@@ -33,7 +33,7 @@ model("Test")->onTest();
 
 ### `request()`
 
-Accesses the instance of the current request.
+Accesses the instance of the [current request](../api/classes/ZubZet-Framework-Message-Request.html).
 
 **Syntax:** `request()`
 
@@ -48,7 +48,7 @@ request()->getPost("POST_PARAMETER");
 
 ### `response()`
 
-Accesses the instance of the current response.
+Accesses the instance of the [current response](../api/classes/ZubZet-Framework-Message-Response.html).
 
 **Syntax:** `response()`
 
@@ -63,7 +63,7 @@ response()->sendEMail($to, $subject, $document);
 
 ### `config()`
 
-Retrieves a configuration value by its key.
+Retrieves a [configuration value](configuration.md) by its key.
 
 **Syntax:** `config(string $key, bool $useDefault = false, mixed $default = null)`
 
@@ -84,7 +84,7 @@ config("db_username");
 
 ### `user()`
 
-Returns the instance of the currently authenticated user.
+Returns the instance of the [currently authenticated user](../api/classes/ZubZet-Framework-Authentication-User.html).
 
 **Syntax:** `user()`
 
@@ -101,7 +101,7 @@ user()->userId;
 
 ### `db()`
 
-Provides the database instance for a specified connection.
+Provides the [database instance](../api/classes/ZubZet-Framework-Database-Connection.html) for a specified connection.
 
 **Syntax:** `db(string $connection = "default")`
 
@@ -140,7 +140,7 @@ logger("payments")->warning("Timeout", ["orderId" => $id]);
 
 ### `view()`
 
-Renders a view template directly.
+Renders a [view template](views.md) directly.
 
 **Syntax:** `view(string $document, array $opt = [], array $options = [])`
 

--- a/docs/core-features/layouts.md
+++ b/docs/core-features/layouts.md
@@ -1,6 +1,6 @@
 # Using a layout in your project
 ## What is a layout?
-When talking about a layout, a reusable page structure is meant. To an extent, most content pages look very similar. Think navigation or footer. A perfect opportunity for generalization. A view is rendered *into* a layout: the layout is the page shell, the view fills in the content.
+When talking about a layout, a reusable page structure is meant. To an extent, most content pages look very similar. Think navigation or footer. A perfect opportunity for generalization. A [view](views.md) is rendered *into* a layout: the layout is the page shell, the view fills in the content.
 
 ## How a layout works
 A layout is a `.blade.php` file that defines the page shell and marks where a view's sections go with `@yield`:
@@ -33,7 +33,7 @@ A layout is a `.blade.php` file that defines the page shell and marks where a vi
 ```
 - `@yield("content")` is where the view's `@section("content")` lands, the main page body.
 - `@yield("head")` is where the view's optional `@section("head")` lands, inside the document `<head>`.
-- `<x-zubzet::head :opt="$opt"/>` and `<x-zubzet::body :opt="$opt"/>` pull in the framework essentials (jQuery, Bootstrap, Font Awesome, Z.js and the debug bar). Include them in every full page layout: the head component inside `<head>`, the body component at the end of `<body>`. Pass the render data through with `:opt="$opt"`.
+- `<x-zubzet::head :opt="$opt"/>` and `<x-zubzet::body :opt="$opt"/>` pull in the framework essentials (jQuery, Bootstrap, Font Awesome, Z.js and the [debug bar](debug-bar.md)). Include them in every full page layout: the head component inside `<head>`, the body component at the end of `<body>`. Pass the render data through with `:opt="$opt"`.
 
 A view then selects and fills this layout:
 ```blade
@@ -50,7 +50,7 @@ A view then selects and fills this layout:
 Because the view carries `@extends($layout)` rather than naming a specific layout, the same view works with whatever layout you hand it, which is what makes switching layouts per request possible.
 
 ## How to use one in your project?
-When using `$res->render`, a third optional parameter accepts a path to a layout. If no parameter is given, the render engine will look for a layout with the standard name in your views folder. The standard location for a layout is `{your z_views folder}/layout/default_layout.blade.php`. If you wish to use a different location, you'll need to use the third parameter to specify a different path. This also allows you to use multiple layouts within the same project and even switch dynamically for content pages.
+When using [`$res->render`](../api/classes/ZubZet-Framework-Rendering-CanRenderView.html#method_render), a third optional parameter accepts a path to a layout. If no parameter is given, the render engine will look for a layout with the standard name in your views folder. The standard location for a layout is `{your z_views folder}/layout/default_layout.blade.php`. If you wish to use a different location, you'll need to use the third parameter to specify a different path. This also allows you to use multiple layouts within the same project and even switch dynamically for content pages.
 
 ### Example usage
 ```php
@@ -60,4 +60,4 @@ public function action_index(Request $req, Response $res) {
 ```
 
 ## Setting a default layout for part of your app
-When `$res->render` is called without an explicit layout, the framework picks one in this order: per-instance default → global default → `layout/default_layout`. Use `$res->setDefaultLayout("admin/layout")` from a route middleware (instance scope) or `Response::setGlobalDefaultLayout("admin/layout")` from a controller `__construct` (request scope) to change that default for a section of the app. Both scopes also expose `pushDefaultLayout` / `popDefaultLayout` (and the global equivalents) so nested components can install a layout and restore the previous one when they're done.
+When `$res->render` is called without an explicit layout, the framework picks one in this order: per-instance default → global default → `layout/default_layout`. Use [`$res->setDefaultLayout("admin/layout")`](../api/classes/ZubZet-Framework-Rendering-Resolver-DefaultLayout.html#method_setDefaultLayout) from a [route middleware](routing.md#middleware-and-aftermiddleware) (instance scope) or `Response::setGlobalDefaultLayout("admin/layout")` from a controller `__construct` (request scope) to change that default for a section of the app. Both scopes also expose `pushDefaultLayout` / `popDefaultLayout` (and the global equivalents) so nested components can install a layout and restore the previous one when they're done.

--- a/docs/core-features/logging.md
+++ b/docs/core-features/logging.md
@@ -44,7 +44,7 @@ Log levels follow the [Monolog/PSR-3 standard](https://www.php-fig.org/psr/psr-3
 
 ## Writing Log Entries
 
-Use the global `logger()` helper function anywhere in your application.
+Use the global `logger()` [helper function](global-helper-functions.md) anywhere in your application.
 
 ```php
 // Log to the app channel
@@ -73,7 +73,7 @@ The second parameter `$context` is an optional associative array with additional
 
 ## Registering a Custom Logger
 
-If you need full control over a logger — custom handlers, formatters, or processors — you can build a Monolog `Logger` instance manually and register it under a channel name using `LoggerFactory::register()`. Once registered, it is returned by `logger()` like any other channel.
+If you need full control over a logger — [custom handlers, formatters, or processors](https://github.com/Seldaek/monolog/blob/main/doc/02-handlers-formatters-processors.md) — you can build a Monolog `Logger` instance manually and [register it under a channel name](../api/classes/ZubZet-Framework-Logger-LoggerFactory.html#method_register) using `LoggerFactory::register()`. Once registered, it is returned by `logger()` like any other channel.
 
 ```php
 use Monolog\Logger;
@@ -166,7 +166,7 @@ logger_type = stream
 logger_stream_url = php://stderr
 ```
 
-`logger_stream_url` accepts any valid PHP stream URL or file path:
+`logger_stream_url` accepts any valid [PHP stream URL](https://www.php.net/manual/en/wrappers.php) or file path:
 
 ```ini
 logger_stream_url = php://stderr

--- a/docs/core-features/maintenance.md
+++ b/docs/core-features/maintenance.md
@@ -9,7 +9,7 @@ A standalone gate that runs immediately after configuration loads, before the lo
 | `enabled`  | Blocked                      | Pass through |
 | `full`     | Blocked                      | Blocked      |
 
-Set this mode in the settings file or as usual using an ENV variable.
+Set this mode in the [settings file](configuration.md) or as usual using an ENV variable.
 
 ```ini
 maintenance_mode = enabled
@@ -18,7 +18,7 @@ maintenance_mode = enabled
 Case-insensitive. Unknown values fall back to `disabled`.
 
 ## Bypass cookie
-In `soft` mode, requests with a `maintenance` cookie pass through. **The value is not validated**, so any value bypasses. Admins can set it via the admin panel. It expires after 24 hours.
+In `soft` mode, requests with a `maintenance` cookie pass through. **The value is not validated**, so any value bypasses. Admins can set it via the [admin panel](../z-admin/usage.md). It expires after 24 hours.
 
 ## CLI behavior
 In `full` mode, CLI commands write `Service Unavailable` to stderr and exit with code `1`. Use this to pause cron jobs alongside HTTP traffic.
@@ -34,4 +34,4 @@ A template is skipped if empty or if it contains `<?php` (the gate uses `file_ge
 The template is only used for HTTP responses. CLI hits always receive the bare `Service Unavailable` string regardless of mode.
 
 ## Admin panel
-`/z/maintenance` shows the current status and exposes a button to set the bypass cookie. Requires the `admin.maintenance` permission. Only reachable in `disabled` or `soft`-with-cookie; in `enabled` or `full` you must edit the INI directly to toggle off.
+`/z/maintenance` shows the current status and exposes a button to set the bypass cookie. Requires the `admin.maintenance` [permission](permission-system.md). Only reachable in `disabled` or `soft`-with-cookie; in `enabled` or `full` you must edit the INI directly to toggle off.

--- a/docs/core-features/migrations/examples.md
+++ b/docs/core-features/migrations/examples.md
@@ -346,7 +346,7 @@ public function execute(): void {
 
 ## Column Types Reference
 
-Doctrine DBAL supports the following common column types:
+Doctrine DBAL supports the following [common column types](https://www.doctrine-project.org/projects/doctrine-dbal/en/4.4/reference/types.html):
 
 | Type | Description | Options |
 |------|-------------|---------|

--- a/docs/core-features/migrations/index.md
+++ b/docs/core-features/migrations/index.md
@@ -18,7 +18,7 @@ By centralizing these processes, the system provides several key advantages:
 
 ## Available Commands
 
-The following commands are integrated into the ZubZet CLI to manage your database lifecycle efficiently.
+The following commands are integrated into the [ZubZet CLI](../console-commands.md) to manage your database lifecycle efficiently.
 
 ### Import
 
@@ -128,7 +128,7 @@ The Migration system supports **two different file formats**, which can be mixed
     For advanced logic, ZubZet supports **PHP-based migrations**. These files allow you to use the Schema QueryBuilder and conditional logic.
 
     **Class Structure:**  
-    Every PHP migration must extend the base `Migration` class and implement the `execute()` method.
+    Every PHP migration must extend the base [`Migration`](../../api/classes/ZubZet-Framework-Database-Migration-Migration.html) class and implement the `execute()` method.
 
     ```php
     use ZubZet\Framework\Database\Migration\Migration;
@@ -319,7 +319,7 @@ The Seed system supports **two different file formats**, which can be mixed free
 
 - **PHP Seed Files (`.php`)**
 
-    For complex data generation or dynamic logic, ZubZet supports **PHP-based seed files**. These files must extend the base `Seed` class.
+    For complex data generation or dynamic logic, ZubZet supports **PHP-based seed files**. These files must extend the base [`Seed`](../../api/classes/ZubZet-Framework-Database-Migration-Seed.html) class.
 
     **Class Structure:**  
     Each seed class must implement a `run()` method where all database operations are defined.
@@ -344,7 +344,7 @@ The Seed system supports **two different file formats**, which can be mixed free
 
 
     **QueryBuilder Usage:**  
-    PHP seed files utilize **CakePHP\Database** for building queries.
+    PHP seed files utilize **[CakePHP\Database](https://book.cakephp.org/4.x/orm/query-builder.html)** for building queries.
 
     For more detailed information about the Query Builder, see: [QueryBuilder](../query-builder/index.md)
 

--- a/docs/core-features/models.md
+++ b/docs/core-features/models.md
@@ -3,11 +3,11 @@
 A model depicts all interactions with your data structure. This is usually either the database or a file. The model can be used to retrieve data as well as set it.
 
 ## How to use it
-If you have already created a model, you can simply use `$req->getModel("Modelname")` in a controller action to call the model.  
+If you have already created a model, you can simply use `$req->getModel("Modelname")` in a [controller action](controllers-and-actions.md) to call the model.  
 Otherwise, if you are within a model and need to call another model, you can use `$this->getModel("Modelname")`.
 
 ### Built-In Functionality
-Every model inherits many useful methods from the z_model class. You can simply use the already existing methods and build on them.
+Every model inherits many useful methods from the [z_model](../api/classes/ZubZet-Framework-Core-Model.html) class. You can simply use the already existing methods and build on them.
 
 ## Example Model
 ```php
@@ -33,7 +33,7 @@ Every model inherits many useful methods from the z_model class. You can simply 
 ```
 
 
-The method `exec` is probably the most important one for your model. It incorporates all the steps for a prepared statement in one simple line. The first parameter is the sql command as a variable or string literal. The second parameter is a string literal of all the variable types. Each char represents one variable. All parameters afterwards are expected to be variables and replace the question marks within the sql command.
+The method [`exec`](../api/classes/ZubZet-Framework-Core-Model.html#method_exec) is probably the most important one for your model. It incorporates all the steps for a [prepared statement](https://www.php.net/manual/en/mysqli.quickstart.prepared-statements.php) in one simple line. The first parameter is the sql command as a variable or string literal. The second parameter is a string literal of all the variable types. Each char represents one variable. All parameters afterwards are expected to be variables and replace the question marks within the sql command.
 
 ### Prepared types
 | Type | Description | Use Cases                                    |
@@ -56,10 +56,10 @@ $this->exec($sql, "si", "Klaus", 30);
 ### Execute Features
 | Type             | Description |
 | ---------------- | ----------- |
-| resultToLine()   | Converts the first row of the query result into a flat array (one-dimensional), often useful when fetching a single row of data. |
-| resultToArray()  | Converts the result set of a query into an array where each row is represented as an associative array.|
-| getInsertId()    | Get the last insert id. |
-| countResults     | Returns the number of results in the last query. |
+| [resultToLine()](../api/classes/ZubZet-Framework-Database-Interaction.html#method_resultToLine)   | Converts the first row of the query result into a flat array (one-dimensional), often useful when fetching a single row of data. |
+| [resultToArray()](../api/classes/ZubZet-Framework-Database-Interaction.html#method_resultToArray)  | Converts the result set of a query into an array where each row is represented as an associative array.|
+| [getInsertId()](../api/classes/ZubZet-Framework-Database-Interaction.html#method_getInsertId)    | Get the last insert id. |
+| [countResults](../api/classes/ZubZet-Framework-Database-Interaction.html#method_countResults)     | Returns the number of results in the last query. |
 
 ### Tips
 ??? danger "Why not simply write queries without question marks?"

--- a/docs/core-features/mvc.md
+++ b/docs/core-features/mvc.md
@@ -1,13 +1,13 @@
 # Models, Views and Controllers (Structure)
 
-A model-view-controller (MVC) is an architectural design pattern that organizes an application's logic into distinct layers, each of which carries out a specific set of tasks.
+A [model-view-controller (MVC)](https://en.wikipedia.org/wiki/Model%E2%80%93view%E2%80%93controller) is an architectural design pattern that organizes an application's logic into distinct layers, each of which carries out a specific set of tasks.
 
 ## **What's a model?**
-The model depicts all interactions with your data structure. This is usually the database or a different data medium.
+The [model](models.md) depicts all interactions with your data structure. This is usually the database or a different data medium.
 The model can be used to retrieve, update and remove data.
 
 ## **What's a controller?**
-It handles all the sites logic. Routing is Based on the name of the controller and its actions. This Interacts with models and renders views.
+It handles all the sites logic. [Routing](routing.md) is Based on the name of the [controller](controllers-and-actions.md) and its actions. This Interacts with models and renders views.
 
 ## **What's a view?**
-A view contains the html the user should see. All additional resources like css, images or javascript are also loaded from views. Views do usually **not** contain a footer, navigation, header or other elements that belong to the overall layout of the page. For this, layouts should be used as without a layout, a view can't be renderer. Read more about layouts [here](layouts.md).
+A [view](views.md) contains the html the user should see. All additional resources like css, images or javascript are also loaded from views. Views do usually **not** contain a footer, navigation, header or other elements that belong to the overall layout of the page. For this, layouts should be used as without a layout, a view can't be renderer. Read more about layouts [here](layouts.md).

--- a/docs/core-features/parameter-abstraction.md
+++ b/docs/core-features/parameter-abstraction.md
@@ -2,7 +2,7 @@
 ## URL Parameters
 When using virtual links, parameters as “subfolders” is a great way of transfering values, that are also very readable. See the following link schema as an example of what is meant by parametres within the virtual link: `controller/action/param0/param1/param2/...`
 ### Read the parameters using code
-To read the virtual url parameters use `$req->getParameters`. It works using an offset and a length, but can also use a value to compare against if the length is one.
+To [read the virtual url parameters](../api/classes/ZubZet-Framework-Message-Request.html#method_getParameters) use `$req->getParameters`. It works using an offset and a length, but can also use a value to compare against if the length is one.
 ### Examples
 Example URL:<br>
 `www.yourwebsite.com/{controller}/{action}/a/b/c`
@@ -45,18 +45,23 @@ public function action_employee(Request $req, Response $res) {
 ```
 
 ## GET, POST, COOKIES, FILE as a method
-The framework includes some extra functionality when it comes to the above mentioned features and you should use the framework instead of the traditional way. This is because the framework employes extra filtering and processing methods as well as error handling already for you.
+The framework includes some extra functionality when it comes to the above mentioned features and you should use the framework instead of the traditional way. This is because the framework employes extra filtering and processing methods as well as [error handling](error-handling.md) already for you.
 
 ### Getting POST and GET parameters
-`$req->getGet` and `$req->getPost` are methods to get form parameters. These also enable to set default parameters if some are not set.<br>
+`$req->getGet` and `$req->getPost` are [methods to get form parameters](../api/classes/ZubZet-Framework-Message-Input-CanRetrieveFromInput.html). These also enable to set default parameters if some are not set.<br>
 **Note:** Post parameters get decoded automatically if their values have the special prefix `<#decURI#>`. This decoding allows to transmit special characters.
 
 ### Cookies
 `$req->getCookie` gets a cookie. It has a second parameter to set a default if the cookie is not set.
 
-`$res->setCookie` has the same parameters as the native `setcookie` function of php. It should be used, because in the future may more logic build into the framework that deals with cookies.
+`$res->setCookie` has the [same parameters](https://www.php.net/manual/en/function.setcookie.php) as the native `setcookie` function of php. It should be used, because in the future may more logic build into the framework that deals with cookies.
 
 `$res->unsetCookie` is an advanced method to remove cookies from the client.
 
 ### File
 `$req->getFile` uses `$_FILE` like `$req->getPost` uses `$_POST`.
+
+## See also
+
+- [Aliases and virtual links](../advanced-features/aliases-and-virtual-links.md): shorter or alternative versions of your virtual links
+- [File uploads](../forms/file-uploads.md): validating and processing files received via `$req->getFile`

--- a/docs/core-features/password-handling.md
+++ b/docs/core-features/password-handling.md
@@ -1,6 +1,6 @@
 # Password Handling
 
-ZubZet hashes passwords with PHP's native **Argon2id**. The framework stores
+ZubZet hashes passwords with PHP's native **[Argon2id](https://www.rfc-editor.org/info/rfc9106/)**. The framework stores
 enough information alongside every hash to verify it, to recognise older hashes,
 and to upgrade them to the current algorithm automatically. Application code
 normally never touches a hash directly: the [`User`](permission-system.md) API
@@ -28,7 +28,7 @@ the three formats can coexist while older accounts upgrade on their own.
 
 | Scheme | `password` holds | `salt` | Notes |
 | ------ | ---------------- | ------ | ----- |
-| `native` | An Argon2id hash from `password_hash()`. | `NULL` | The target format for every account. |
+| `native` | An Argon2id hash from [`password_hash()`](https://www.php.net/manual/en/function.password-hash.php). | `NULL` | The target format for every account. |
 | `legacy` | The hash produced by the framework's previous scheme. | set | Verify only. Upgraded to `native` on the next login. |
 | `onion` | A native Argon2id hash wrapping the legacy value. | set | A dormant account moved onto Argon2id ahead of its next login. Upgraded to `native` when the owner logs in. |
 
@@ -73,14 +73,14 @@ if ($user && $user->verifyPassword($plaintext)) {
 }
 ```
 
-`User::verifyPassword()` returns a boolean and is self healing: on a correct
+[`User::verifyPassword()`](../api/classes/ZubZet-Framework-Authentication-Permission-User.html#method_verifyPassword) returns a boolean and is self healing: on a correct
 login it transparently upgrades a stale stored hash to a current `native` hash
 (see [Self healing upgrades](#self-healing-upgrades)). It is the password check
 used by the framework's own login flow.
 
 ## The hash and verify API
 
-`User` is built on the lower level `ZubZet\Framework\Authentication\PasswordHash\Password`
+`User` is built on the lower level [`ZubZet\Framework\Authentication\PasswordHash\Password`](../api/classes/ZubZet-Framework-Authentication-PasswordHash-Password.html)
 class, which you can use directly when you are not working with a `User` object.
 
 ### Hashing
@@ -105,7 +105,7 @@ if ($result->isCorrect()) {
 }
 ```
 
-`Password::verify()` returns a `Verification` value object rather than a bare
+`Password::verify()` returns a [`Verification`](../api/classes/ZubZet-Framework-Authentication-PasswordHash-Verification.html) value object rather than a bare
 boolean, so a single call can also report whether the stored hash should be
 refreshed:
 
@@ -134,7 +134,7 @@ password. On a successful login, the stored hash is upgraded to a fresh
 - the account is still `legacy` or `onion`, or
 - the account is `native` but was hashed below the current cost.
 
-The second case relies on PHP's `password_needs_rehash()`. When you raise the
+The second case relies on PHP's [`password_needs_rehash()`](https://www.php.net/manual/en/function.password-needs-rehash.php). When you raise the
 Argon2id cost (see below), existing users are migrated one at a time as they log
 in, with no bulk operation and no forced reset.
 
@@ -149,7 +149,7 @@ the next login.
 
 ## Migrating an existing installation
 
-When you upgrade the framework, the schema migration runs automatically and
+When you upgrade the framework, the [schema migration](migrations/index.md) runs automatically and
 marks every existing password row as `legacy`. Those accounts keep working
 unchanged and upgrade themselves to `native` on the next login.
 
@@ -176,7 +176,7 @@ additional transformation step, provided by a dedicated hashing library. That
 scheme served the framework reliably and shipped in production for a long time.
 
 Version 1.2.0 modernises password storage onto PHP's native Argon2id, the
-algorithm recommended by the current OWASP Password Storage guidance. Argon2id
+algorithm recommended by the current [OWASP Password Storage guidance](https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html). Argon2id
 is memory hard and purpose built for password storage, the native PHP functions
 are maintained as part of the language and run in constant time, and every
 stored value embeds its own algorithm, cost, and salt. That self describing

--- a/docs/core-features/permission-system.md
+++ b/docs/core-features/permission-system.md
@@ -2,7 +2,7 @@
 
 
 ## Basic explanation
-A user can have multiple roles, and each role can have multiple permissions. These can be managed in the admin panel.
+A user can have multiple [roles](access-control.md), and each role can have multiple permissions. These can be managed in the [admin panel](../z-admin/usage.md).
 
 ## Roles
 Roles are the things that holds permissions. A role can be created with the Z-Admin panel (`{root}/z`).
@@ -13,7 +13,7 @@ The assignment can also be done with the Z-Admin panel.
 Permissions are structured as multiple keywords connected by periods. For example: `admin.user.create`. This is descriptive as it can be seen that this permission is for admins with access to the user management and creating users. This style of writing permissions allows also the usage of wildcards. To `admin.user.create` someone with these permissions will have access to it: `*.*`, `admin.*`, `amdin.user.*` and `admin.user.create`. `*.*` is a wildcard for all permissions. **Use it on you own risk**.
 
 ## Blocking forbidden pages
-The Request object has a method called `checkPermission`.
+The Request object has a method called [`checkPermission`](../api/classes/ZubZet-Framework-Message-Request.html#method_checkPermission).
 By calling it, all users without the permission given as the parameter will be rerouted to the 403 page and the current request will be cancled.
 So it is wise to call this at the very beginning of an action.
 
@@ -37,7 +37,7 @@ public function action_view(Request $req, Response $res) {
 }
 ```
 ## Checking permissions while rendering the page
-To check if the requesting user has a permission, the user object in `$opt` can be used. It has a method called `checkPermission` that returns a boolean. **Note** that this is **another** method than `checkPermission` from the request object. This one does not redirect the user and can be used for example to determin if specific should be visible to the user on a page it generally has access to.
+To check if the requesting user has a permission, the user object in `$opt` can be used. It has a method called [`checkPermission`](../api/classes/ZubZet-Framework-Authentication-User.html#method_checkPermission) that returns a boolean. **Note** that this is **another** method than `checkPermission` from the request object. This one does not redirect the user and can be used for example to determin if specific should be visible to the user on a page it generally has access to.
 
 ### View example:
 ```blade

--- a/docs/core-features/query-builder/examples.md
+++ b/docs/core-features/query-builder/examples.md
@@ -1,6 +1,6 @@
 # Query Builder Examples
 
-This page provides detailed examples for building queries with the CakePHP Query Builder in ZubZet.
+This page provides detailed examples for [building queries](./index.md) with the CakePHP Query Builder in ZubZet.
 
 ---
 

--- a/docs/core-features/query-builder/index.md
+++ b/docs/core-features/query-builder/index.md
@@ -9,7 +9,7 @@ The Query Builder allows you to build SQL queries programmatically in a safe and
 
 ## How it works
 
-Inside a [model](../models.md), you can now use helper methods like `select`, `update`, `delete`, and `insert`.
+Inside a [model](../models.md), you can now use [helper methods](../../api/classes/ZubZet-Framework-QueryBuilder-CanBuildQuery.html) like `select`, `update`, `delete`, and `insert`.
 These methods internally delegate to the CakePHP Query Builder.
 
 Example methods inside a model:
@@ -40,7 +40,7 @@ public function getQueryBuilder() {
 
 ## Executing Queries
 
-Once you have built a query, you can execute it with the `exec` method:
+Once you have built a query, you can execute it with the [`exec`](../../api/classes/ZubZet-Framework-Core-Model.html#method_exec) method:
 ```php
 
 $query = $this->dbSelect(...);

--- a/docs/core-features/rest-api.md
+++ b/docs/core-features/rest-api.md
@@ -1,9 +1,9 @@
 # REST Responses
 ## What is this?
-As the client and the server are completely separated, they need to have a way communicated. It is basically a standardized way of transfering, in our case JSON data, from the server to the client.
+As the [client](../frontend-integration/backend-requests.md) and the server are completely separated, they need to have a way communicated. It is basically a standardized way of transfering, in our case JSON data, from the server to the client.
 
 ## How to use this?
-The REST response pipeline lives in `z_rest.php`, but you'll typically reach for one of the response helpers instead:
+The [REST response pipeline](../api/classes/ZubZet-Framework-Support-Rest.html) lives in `z_rest.php`, but you'll typically reach for one of the response helpers instead:
 
 | Call                      | Purpose                                                                     |
 | ------------------------- | --------------------------------------------------------------------------- |
@@ -13,7 +13,7 @@ The REST response pipeline lives in `z_rest.php`, but you'll typically reach for
 | `$res->success`           | Convenience for `generateRest` with `result=success`                        |
 | `$res->json`              | Sends a raw JSON payload (no `meta` wrapper); does not exit                 |
 
-You can also just use generateRest for errors. If the key result is set with the value error, it is automatically converted into a REST Error. The second parameter of generateRest called $die determines if the script exits after generating the REST response. The parameter is optional with a default value of true.
+You can also just use [generateRest](../api/classes/ZubZet-Framework-Message-Response.html#method_generateRest) for errors. If the key result is set with the value error, it is automatically converted into a REST Error. The second parameter of generateRest called $die determines if the script exits after generating the REST response. The parameter is optional with a default value of true.
 
 ## Example Calls
 
@@ -55,7 +55,7 @@ $res->error("MESSAGE");
 ```
 
 ### json
-Use `json` when you need to send a raw JSON payload without the REST `meta` wrapper. It sets `Content-Type: application/json` and echoes `json_encode($data)`. Unlike the other helpers above it does not exit — call `exit` yourself if you need to stop the request here. `JSON_THROW_ON_ERROR` is always applied, so unencodable values raise a `JsonException`.
+Use `json` when you need to [send a raw JSON payload](../api/classes/ZubZet-Framework-Message-Response.html#method_json) without the REST `meta` wrapper. It sets `Content-Type: application/json` and echoes `json_encode($data)`. Unlike the other helpers above it does not exit — call `exit` yourself if you need to stop the request here. `JSON_THROW_ON_ERROR` is always applied, so unencodable values raise a `JsonException`.
 
 ```php
 $res->json([

--- a/docs/core-features/routing.md
+++ b/docs/core-features/routing.md
@@ -30,7 +30,7 @@ Route::{method}({endpoint}, [{ControllerClass}::class, {ControllerAction}]);
 
 ### Explanation
 
-1. **`method`** → One of the supported HTTP methods:
+1. **`method`** → One of the supported [HTTP methods](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Methods):
 
     - `any(endpoint, action)` → Match any HTTP method
     - `get(endpoint, action)` → Match `GET` requests
@@ -180,7 +180,7 @@ To access a parameter inside a controller action, you can use:
 $req->getRouteParameter("key");
 ```
 
-If you call `$req->getRouteParameter()` without passing a key, it will return **all route parameters** as an array.
+If you call [`$req->getRouteParameter()`](../api/classes/ZubZet-Framework-Message-Request.html#method_getRouteParameter) without passing a key, it will return **all route parameters** as an array.
 
 ### Example
 

--- a/docs/core-features/views.md
+++ b/docs/core-features/views.md
@@ -6,7 +6,7 @@ A view contains the HTML the user should see, along with the CSS, images and Jav
 Database access and heavy logic should not be used in the view, as that belongs into other parts of the application.
 
 ## The render engine
-Since v1.3.0 ZubZet renders views with [Katana](https://github.com/katanaphp/blade), a standalone implementation of the [Blade](https://laravel.com/docs/13.x/blade) templating language. A view is a `.blade.php` file placed in your project's `z_views` directory, otherwise it will not be found when called from the render method.
+Since v1.3.0 ZubZet renders views with [Katana](https://github.com/katanaphp/blade), a standalone implementation of the [Blade](https://laravel.com/docs/13.x/blade) templating language. A view is a `.blade.php` file placed in your project's `z_views` directory, otherwise it will not be found when called from the [render method](../api/classes/ZubZet-Framework-Rendering-CanRenderView.html#method_render).
 
 Blade gives you a concise syntax for the things you do in every template: escaping output, loops, conditionals, reusable components and page inheritance. This page covers the parts you reach for day to day, which is most of what you need. For the complete directive reference, the [Laravel Blade documentation](https://laravel.com/docs/13.x/blade) is the final backstop (Katana implements the common Blade set, see [Not available in Katana](#not-available-in-katana)).
 
@@ -22,7 +22,7 @@ A view extends a layout and fills in its content:
     <h1>Hello World</h1>
 @endsection
 ```
-`@extends($layout)` plugs the view into the layout the controller chose. The framework passes the layout name in as `$layout`, so you never hardcode it. `@section("content")` is the main body, and the layout decides where it lands. An optional `@section("head")` adds page specific tags to the document `<head>` (a stylesheet, a meta tag). Read more about how the two fit together in [Layouts](layouts.md).
+`@extends($layout)` plugs the view into the layout the [controller](controllers-and-actions.md) chose. The framework passes the layout name in as `$layout`, so you never hardcode it. `@section("content")` is the main body, and the layout decides where it lands. An optional `@section("head")` adds page specific tags to the document `<head>` (a stylesheet, a meta tag). Read more about how the two fit together in [Layouts](layouts.md).
 
 ## Passing data
 Whatever you pass to `render` is available in the view, both as a top level variable and inside the `$opt` array:

--- a/docs/core-features/views.md
+++ b/docs/core-features/views.md
@@ -54,7 +54,7 @@ The framework also injects a set of helpers into `$opt` for every render: `$opt[
 {{-- this is a comment and is not rendered --}}
 {{ $title ?? "Untitled" }}   {{-- any PHP expression works inside the braces --}}
 ```
-`{{ }}` escapes its output the same way the framework's `e()` helper does, so it is safe for user input by default. Use `{!! !!}` only for HTML you trust.
+`{{ }}` escapes its output the same way the framework's [`e()` helper](global-helper-functions.md#e) does, so it is safe for user input by default. Use `{!! !!}` only for HTML you trust.
 
 ## Conditionals
 ```blade

--- a/docs/forms/auto-form-validation.md
+++ b/docs/forms/auto-form-validation.md
@@ -28,10 +28,10 @@ The form is created with `Z.Forms.create`. The `dom` attribute takes the id of a
 | Attribute   | Description                                                                                                                                                                                                                                                                                                    |
 |-------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `name`      | Corresponds to the name in the post request.                                                                                                                                                                                                                                                                   |
-| `type`      | The input type. Any valid HTML standard type is accepted, as well as `textarea`, `select`, `multi-select`, and `autocomplete`. This attribute does not affect server-side value parsing.                                                                                                                       |
+| `type`      | The input type. Any valid [HTML standard type](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input) is accepted, as well as `textarea`, `select`, `multi-select`, and `autocomplete`. This attribute does not affect server-side value parsing.                                                                                                                       |
 | `text`      | Label text for the input field.                                                                                                                                                                                                                                                                               |
 | `value`     | Default value for the input field. For `multi-select`, pass an array (e.g. `["1","4"]`) or `<?= json_encode([...]) ?>`.                                                                                                                                                                                       |
-| `food`      | Required for `select` and `multi-select` types. It defines the options available and is formatted as an array: `[{value: 1, text: "one"}, {value: 2, text: "two"}, ...]`. This array can be generated via `$controller->makeFood`.                                                                              |
+| `food`      | Required for `select` and `multi-select` types. It defines the options available and is formatted as an array: `[{value: 1, text: "one"}, {value: 2, text: "two"}, ...]`. This array can be generated via [`$controller->makeFood`](../api/classes/ZubZet-Framework-Core-Controller.html#method_makeFood).                                                                              |
 | `required`  | Specifies whether the field is required. When set to `true`, the input must be filled before form submission.                                                                                                                                                                                                  |
 | `width`     | Defines the width of the form element in 1/12 units of the total width. Effective on medium or larger devices. On small devices, the width is always 100%.                                                                                                                                                      |
 | `attributes`| Allows adding additional attributes for the generated input element (e.g., `min`, `max` for number inputs). Example usage: `attributes: {'min': 1, 'max': 10}`.                                                                                                                                                  |
@@ -102,7 +102,7 @@ form.setValues({ first_name: "Ada" });  // set the named fields
 form.setValues(data, { resetUnknown: true }); // reset fields not present in data first
 ```
 
-CED fields are skipped by `getValues` / `setValues`; their data round-trips through the normal submit instead.
+[CED](ced-validation.md) fields are skipped by `getValues` / `setValues`; their data round-trips through the normal submit instead.
 
 Keys passed to `setValues` that don't match any field are kept on `form.meta` and returned by `getValues`, but are never submitted to the backend. This lets a value like an id ride along with the form data:
 
@@ -128,7 +128,7 @@ var form = Z.Forms.create({
 
 ## Back-end
 When the form is submitted, it will send an asynchronous post request to the current action specified by the current users url.
-To check in the action if the current request is from a form, `$req->hasFormData()` can be used. This is example code for handling a form:
+To check in the action if the current request is from a form, [`$req->hasFormData()`](../api/classes/ZubZet-Framework-Message-Request.html#method_hasFormData) can be used. This is example code for handling a form:
 
 ### **Backend validation**
 ```php
@@ -150,11 +150,11 @@ if ($req->hasFormData()) {
 
 `$req->hasFormData()` checks if there is any data in the request.
 
-`$req->validateForm()` validates the values.
+[`$req->validateForm()`](../api/classes/ZubZet-Framework-Form-Validation-CanValidateForm.html#method_validateForm) validates the values.
 As the first parameter it takes an array of fields to validate. To these field, rules can be attached.
 
 `$formResult->hasErrors` returns true or false depended on the validation result of `$req->validateForm()`.
-If the validation fails, `$res->formErrors($formResult->errors)` will return the errors to the frontend, where they will be displayed.
+If the validation fails, [`$res->formErrors($formResult->errors)`](../api/classes/ZubZet-Framework-Message-Response.html#method_formErrors) will return the errors to the frontend, where they will be displayed.
 
 ### **Rules on array values (multi-select)**
 
@@ -176,14 +176,14 @@ $formResult = $req->validateForm([
 
 ### **Saving functions**
 
-Success will exit the current action. So before calling it the data should be processed by a model or `$res->updateDatabase()`.
-Update database will take the result object from the form validation to get the names in the database. If the name in the database column and the post differ, the database name can be set by the second parameter of the `constructor of FormField`.
+Success will exit the current action. So before calling it the data should be processed by a model or [`$res->updateDatabase()`](../api/classes/ZubZet-Framework-Message-Response.html#method_updateDatabase).
+Update database will take the result object from the form validation to get the names in the database. If the name in the database column and the post differ, the database name can be set by the second parameter of the [`constructor of FormField`](../api/classes/ZubZet-Framework-Form-Validation-Field.html#method___construct).
 
-`$res->insertDatabase()` can also be used to process the data. This method will create a dataset in a table given as argument. It works similar to `$res->updateDatabase()`.
+[`$res->insertDatabase()`](../api/classes/ZubZet-Framework-Message-Response.html#method_insertDatabase) can also be used to process the data. This method will create a dataset in a table given as argument. It works similar to `$res->updateDatabase()`.
 
 
 ### **insertOrUpdateDatabase Example**
-`$req->insertOrUpdateDatabase()` Adds a logic to check if the dataset already exists.
+[`$req->insertOrUpdateDatabase()`](../api/classes/ZubZet-Framework-Message-Response.html#method_insertOrUpdateDatabase) Adds a logic to check if the dataset already exists.
 ```php
 public function action_manage(Request $req, Response $res) {
     $req->checkPermission("employee.edit");
@@ -322,7 +322,7 @@ public function action_manage(Request $req, Response $res) {
     - checkbox
 
 ### Checkbox
-The `checkbox` type renders with a Bootstrap `form-check` layout: the box sits to the left of its label, and clicking the label toggles the box. `text` becomes the label.
+The `checkbox` type renders with a [Bootstrap](https://getbootstrap.com/docs/4.6/components/forms/) `form-check` layout: the box sits to the left of its label, and clicking the label toggles the box. `text` becomes the label.
 
 ```js
 form.createField({

--- a/docs/forms/auto-form-validation.md
+++ b/docs/forms/auto-form-validation.md
@@ -1,7 +1,7 @@
 # Auto form validation and database updates
 This framework has the ability to create automatic generated forms with user feedback. These forms can be validated automatically on the server and if errors occur the feedback is sent back to the user. If no errors occur the data can be used to update a database table.
 ## Front-end
-To create the form on the frontend, use the Z.js library. An example form can be created with this code:
+To create the form on the frontend, use Z.js, the framework's bundled frontend script. It is served through the [asset proxy](../core-features/asset-proxy.md) and included automatically by the framework's default head component, so the global `Z` object is available in every properly set up [layout](../core-features/layouts.md). An example form can be created with this code:
 ```javascript
 var form = Z.Forms.create({dom: "form"});
 

--- a/docs/forms/ced-validation.md
+++ b/docs/forms/ced-validation.md
@@ -2,6 +2,8 @@
 Some forms require the user to input multiple values into one field. Or to create multiple blocks or something. For every case this happens the CED system can be used. CED stands for **C**reate **E**dit **D**elete. It builds on top of the [form system](auto-form-validation.md).
 
 ## Front-end
+Like the rest of the form system, the frontend is provided by the bundled [Z.js](auto-form-validation.md#front-end) script, which exposes the global `Z` object used below.
+
 This is an example for adding permissions to a group. It is possible to have n permissions per group.
 ```js
 var form = Z.Forms.create({dom: "form"});

--- a/docs/forms/ced-validation.md
+++ b/docs/forms/ced-validation.md
@@ -1,5 +1,5 @@
 # Auto form validation using CED
-Some forms require the user to input multiple values into one field. Or to create multiple blocks or something. For every case this happens the CED system can be used. CED stands for **C**reate **E**dit **D**elete. It builds on top of the form system.
+Some forms require the user to input multiple values into one field. Or to create multiple blocks or something. For every case this happens the CED system can be used. CED stands for **C**reate **E**dit **D**elete. It builds on top of the [form system](auto-form-validation.md).
 
 ## Front-end
 This is an example for adding permissions to a group. It is possible to have n permissions per group.
@@ -19,7 +19,7 @@ form.createCED({
 ```
 `form.createCED` is a method from ZForm. It takes the same parameters as `form.createField`. The only special one is `fields`. `fields` takes an array of form field parameters. All form fields are build like in `form.createField`.
 
-`value` takes an value created by `$controller->makeCEDFood()`.
+`value` takes an value created by [`$controller->makeCEDFood()`](../api/classes/ZubZet-Framework-Core-Controller.html#method_makeCEDFood).
 
 To create more compact forms, the attribute `compact` can be set to true. On form fields it will hide the label. In CED's it allows to have the remove button at the right. When using the compact mode, the inputs should have a total combined length of 11 units because the remove button will take exactly one.
 ## Back-end
@@ -39,6 +39,6 @@ if ($req->hasFormData()) {
     }
 }
 ```
-`$req->validateCED` takes the name of the CED field at the frontend as the first parameter. The second parameter is equal to the ruleset in `$req->validateForm`. The difference here is that the rules will be applied for all items in the ced. The return value can also be used like of the normal `validateForm` method for error reporting.
+[`$req->validateCED`](../api/classes/ZubZet-Framework-Form-Validation-CanValidateMultiForm.html#method_validateCED) takes the name of the CED field at the frontend as the first parameter. The second parameter is equal to the ruleset in `$req->validateForm`. The difference here is that the rules will be applied for all items in the ced. The return value can also be used like of the normal `validateForm` method for error reporting.
 
-Instead of `$res->updateDatabase`, CED's use `$res->doCED` to update the database. The first parameter is the name of the table. It is important that the table has a field named `active`. This will be used to deterime if a dataset was removed. The other fields should have the same names as the subinputs of the form.
+Instead of `$res->updateDatabase`, CED's use [`$res->doCED`](../api/classes/ZubZet-Framework-Message-Response.html#method_doCED) to update the database. The first parameter is the name of the table. It is important that the table has a field named `active`. This will be used to deterime if a dataset was removed. The other fields should have the same names as the subinputs of the form.

--- a/docs/forms/file-uploads.md
+++ b/docs/forms/file-uploads.md
@@ -1,6 +1,6 @@
 # Working with file uploads
 ## Manual
-Sometimes it is needed that a user uploads a file. To handle incoming files, response has the `upload()` method. It returns a `z_upload` object which has more methods to handle with uploads.
+Sometimes it is needed that a user uploads a file. To handle incoming files, response has the [`upload()`](../api/classes/ZubZet-Framework-Message-Response.html#method_upload) method. It returns a [`z_upload`](../api/classes/ZubZet-Framework-Form-Upload.html) object which has more methods to handle with uploads.
 
 ```php
 $upload = $res->upload();
@@ -11,14 +11,14 @@ if ($upload->upload($_FILES["file"], "uploads/", FILE_SIZE_100GB, ["txt", "jpg",
 $fileId = $upload->fileId;
 ```
 
-`$file` is the file in `$_FILES`.  
+`$file` is the file in [`$_FILES`](https://www.php.net/manual/en/reserved.variables.files.php).  
 `$uploadDir` is the directory to place the file in. Ending with `/`.  
 `$maxSize` is the max file size. For some values there are already constants in the framework.  
 `$typeArray` array of accepted file types.
 
 
 ## Using Z-Forms
-When using Z-Forms, files will be stored and error feedback automatically goes back to the user. For file uploads there is the special rule `file()`.
+When using [Z-Forms](auto-form-validation.md), files will be stored and error feedback automatically goes back to the user. For file uploads there is the special rule [`file()`](../api/classes/ZubZet-Framework-Form-Validation-Field.html#method_file).
 ```
 (new FormField("file")) -> file(FILE_SIZE_1MB, ["txt", "jpg", "png"])
 ```

--- a/docs/frontend-integration/backend-requests.md
+++ b/docs/frontend-integration/backend-requests.md
@@ -15,7 +15,7 @@ $(".delete-employee").click(function() {
     });
 });
 ```
-`Z.Request.action` takes three parameters. The first one is the identifier of the action as string. The second is a object containing post parameters. The third is a callback which only parameter is the REST response of the server.
+`Z.Request.action` takes three parameters. The first one is the identifier of the action as string. The second is a object containing post parameters. The third is a callback which only parameter is the [REST response](../core-features/rest-api.md) of the server.
 ## Back-end
 ```php
 public function action_list(Request $req, Response $res) {
@@ -30,4 +30,4 @@ public function action_list(Request $req, Response $res) {
     return $res->render("employee/list");
 }
 ```
-`$req->isAction()` detects if this Request was initiated by an async action call with a specified identifier. Note that these actions are not the same as the ones in the controller. They work a level higher. `$res->generateRest` will create a parsable answer for the client.
+[`$req->isAction()`](../api/classes/ZubZet-Framework-Message-Request.html#method_isAction) detects if this Request was initiated by an async action call with a specified identifier. Note that these actions are not the same as the ones in the controller. They work a level higher. [`$res->generateRest`](../api/classes/ZubZet-Framework-Message-Response.html#method_generateRest) will create a parsable answer for the client.

--- a/docs/frontend-integration/backend-requests.md
+++ b/docs/frontend-integration/backend-requests.md
@@ -1,5 +1,5 @@
 # Using Z.Request
-The default JavaScript API of this framework does have a function to send asynchronous requests to the server and get data back.
+The default JavaScript API of this framework does have a function to send asynchronous requests to the server and get data back. `Z.Request` is part of Z.js, the framework's bundled frontend script, which is included automatically in every properly set up [layout](../core-features/layouts.md).
 ## Front-end
 ```js
 $(".delete-employee").click(function() {

--- a/docs/frontend-integration/presets.md
+++ b/docs/frontend-integration/presets.md
@@ -1,5 +1,5 @@
 # Z Preset: Login and Register
-The default JavaScript API of this framework (which is included in all [views](../core-features/views.md) using a properly setup [layout](../core-features/layouts.md)) contains presets for some core functionality of a web page.
+The default JavaScript API of this framework, the bundled Z.js script (which is included in all [views](../core-features/views.md) using a properly setup [layout](../core-features/layouts.md)), contains presets for some core functionality of a web page.
 
 For these two examples it is important that the default loginController is used.
 ## Creating a login

--- a/docs/frontend-integration/presets.md
+++ b/docs/frontend-integration/presets.md
@@ -1,5 +1,5 @@
 # Z Preset: Login and Register
-The default JavaScript API of this framework (which is included in all views using a properly setup layout) contains presets for some core functionality of a web page.
+The default JavaScript API of this framework (which is included in all [views](../core-features/views.md) using a properly setup [layout](../core-features/layouts.md)) contains presets for some core functionality of a web page.
 
 For these two examples it is important that the default loginController is used.
 ## Creating a login

--- a/docs/guides/email.md
+++ b/docs/guides/email.md
@@ -74,10 +74,10 @@ To start working with emails, we first need the basic structure of our applicati
     To verify if your emails are being sent correctly, you can navigate to `localhost:3300`. This is a default interface for email testing, which are commonly used in development environments to capture and inspect outgoing emails without actually sending them.
 
 
-Before sending emails, configure your SMTP server. The configuration is located in the `z_config/z_settings.ini` file, where parameters like `mail_smtp` need to be set up.
+Before sending emails, configure your SMTP server. The [configuration](../core-features/configuration.md) is located in the `z_config/z_settings.ini` file, where parameters like `mail_smtp` need to be set up.
 
 ## Sending Emails
-Emails are sent from controllers, and the ZubZet framework provides two methods for this purpose:
+Emails are sent from [controllers](../core-features/controllers-and-actions.md), and the ZubZet framework provides [two methods](../template-rendering-usages/sending-an-email.md) for this purpose:
 
 1. `sendEmail`: This method allows you to send an email to a custom email address. It accepts the following parameters:
 

--- a/docs/guides/guest-list.md
+++ b/docs/guides/guest-list.md
@@ -33,7 +33,7 @@ INSERT INTO `guest` (`first_name`, `last_name`, `email`) VALUES
 
 ## Setting up the Database
 ??? info "What is Migration and what is Seed?"
-    **Migration** refers to the process of modifying a database's structure, such as adding, removing, or altering tables and columns. Migration files document these changes and allow them to be applied automatically across different environments, ensuring the database structure remains consistent and versioned.
+    **[Migration](../core-features/migrations/index.md)** refers to the process of modifying a database's structure, such as adding, removing, or altering tables and columns. Migration files document these changes and allow them to be applied automatically across different environments, ensuring the database structure remains consistent and versioned.
 
     **Seeding** is the process of populating a database with sample or test data. It is commonly used in development and testing environments to provide realistic data for testing or to initialize the database with predefined values for consistency. Seeding is often used alongside migrations to set up the database.
 To define the database structure, go to the `database/migrations` folder. Create a file named `[DATE]_guest.sql`, replacing `[DATE]` with the current date in the format `YYYY-MM-DD`. Then, paste the `CREATE TABLE` statement from the Resources section into the file. 
@@ -115,8 +115,8 @@ The function name is up to you, but adhering to meaningful, consistent names is 
 
 ### Explanation
 1. **SQL Query**: Define the SQL query to retrieve the data.  
-2. **Execute Query**: Use the exec function to execute the query.  
-3. **Process Results**: Convert the query results into an array with resultToArray.  
+2. **Execute Query**: Use the [exec](../api/classes/ZubZet-Framework-Core-Model.html#method_exec) function to execute the query.  
+3. **Process Results**: Convert the query results into an array with [resultToArray](../api/classes/ZubZet-Framework-Core-Model.html#method_resultToArray).  
 4. **Return Data**: Return the guest list for further use.
 
 ## Connecting the Controller and Model
@@ -173,7 +173,7 @@ A controller doesn't always need to render a view. It can handle tasks like proc
 
 
 ### Explanation
-- **render**: Use this method to render a view file.
+- **[render](../api/classes/ZubZet-Framework-Rendering-CanRenderView.html#method_render)**: Use this method to render a view file.
 - **Variables**: Pass variables (like the guest list) as the second parameter to make them available in the view.
 
 ## Displaying Guests in the View

--- a/docs/guides/layout.md
+++ b/docs/guides/layout.md
@@ -1,7 +1,7 @@
 # Layout Guide
 In the [previous guide](todo.md), we explored how to create and manage forms effectively.
 
-In this guide, we'll focus on using **layouts**, a powerful feature in the ZubZet framework. Layouts help you structure your application by organizing your website into distinct sections, such as a **Main Page** and an **Admin Panel**, ensuring a consistent look and feel across multiple pages.
+In this guide, we'll focus on using **[layouts](../core-features/layouts.md)**, a powerful feature in the ZubZet framework. Layouts help you structure your application by organizing your website into distinct sections, such as a **Main Page** and an **Admin Panel**, ensuring a consistent look and feel across multiple pages.
 
 ### Resources
 <details>
@@ -40,7 +40,7 @@ view
 To start working with permissions, we first need the basic structure of our application. This guide provides pre-built files in the [Resources](#resources) section, including templates for controllers and views. Using these resources ensures an organized setup and allows us to focus on implementing functionality and layouts.
 
 ## Creating a Layout
-Layouts in the ZubZet framework are defined as Blade templates within the `z_views` folder. A layout is just the page's HTML shell with `@yield` placeholders where the view's sections are inserted.
+Layouts in the ZubZet framework are defined as [Blade templates](../core-features/views.md) within the `z_views` folder. A layout is just the page's HTML shell with `@yield` placeholders where the view's sections are inserted.
 
 You can add your HTML and framework-related logic within this structure.  
 For instance:

--- a/docs/guides/library.md
+++ b/docs/guides/library.md
@@ -198,7 +198,7 @@ In this example, we will check if the user has the `library.delete` permission. 
 - **Closing PHP for HTML Rendering**: Inside the `if` condition, we close PHP to render the HTML (e.g., a button for editing the book). If the user lacks the permission, the `else` block displays a message (`No Permissions`).
 
 ## How to create Roles and Permissions
-Now that we understand how to use permissions, it’s essential to know how to create them. Here’s a step-by-step guide using the admin panel provided by the framework:
+Now that we understand how to use permissions, it’s essential to know how to create them. Here’s a step-by-step guide using the [admin panel](../z-admin/usage.md) provided by the framework:
 
 1) **Access the Admin Panel**  
 Open your browser and navigate to the admin panel at `http://localhost:8080/z`.

--- a/docs/guides/shop.md
+++ b/docs/guides/shop.md
@@ -1,7 +1,7 @@
 # Shop Application
 In the [last guide](library.md), we explored how to enhance your website's security by implementing roles and permissions to restrict user access effectively.
 
-In this guide, we’ll focus on handling backend requests in your application. Using a Shop example, we will demonstrate how to implement functionality for removing data from the database, triggered by a delete button on the page. This will provide you with the foundation for managing interactive actions securely and efficiently.
+In this guide, we’ll focus on handling [backend requests](../frontend-integration/backend-requests.md) in your application. Using a Shop example, we will demonstrate how to implement functionality for removing data from the database, triggered by a delete button on the page. This will provide you with the foundation for managing interactive actions securely and efficiently.
 
 ### Resources
 <details>
@@ -425,7 +425,7 @@ We then delete the product by calling the `deleteProduct` method in the `ShopMod
 ?>
 ```
 
-Finally, we send a response back to the frontend. The framework provides several response methods, such as:  
+Finally, we send a response back to the frontend. The framework provides several [response methods](../api/classes/ZubZet-Framework-Message-Response.html), such as:  
 
 - `$res->success()`  Indicates the request was successful.
 - `$res->error()` Indicates the request failed.

--- a/docs/guides/todo.md
+++ b/docs/guides/todo.md
@@ -330,7 +330,7 @@ If validation fails, return errors to the frontend using `$res->formErrors()`:
 
 `$formResult->hasErrors()` checks if there is any invalid input. If errors are present, the method return `$res->formErrors($formResult->errors);` sends the errors to the frontend, allowing them to be displayed to the user for correction.
 
-Upon successful validation, use $res->insertDatabase to save the data to a database. Ensure field names in the frontend match database column names:
+Upon successful validation, use [$res->insertDatabase](../api/classes/ZubZet-Framework-Message-Response.html#method_insertDatabase) to save the data to a database. Ensure field names in the frontend match database column names:
 ```php
 <?php
     class TodoController extends z_controller {

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,7 @@
 It is not 100% necessary to use a framework, but especially raw PHP code is usually very messy. This is mostly because the language allows for so many formatting and usage habits, that might not reflect best practices. This adds up. Using a good framework vastly improves your style, but that is not it yet. The biggest advantage is, that ZubZet adds multiple layers of abstraction on top of PHP. This allows you to create webapps in record time. Even an empty project is already capable of a login system, a dashboard, HTML templating and more.
 
 ## Using MVC
-Using this framework effectively, you must understand the MVC pattern, which consists of:
+Using this framework effectively, you must understand the [MVC pattern](core-features/mvc.md), which consists of:
 
 1. [Controllers](core-features/controllers-and-actions.md) handle all the logic within your program. They do the actual computational work.
 

--- a/docs/setup/how-to-update.md
+++ b/docs/setup/how-to-update.md
@@ -1,8 +1,8 @@
 # Updating to the newest version of the framework
-This page assumes you are using this framework as a git submodule .
+This page assumes you are using this framework as a [git submodule](https://git-scm.com/book/en/v2/Git-Tools-Submodules) .
 
 1. Get the newest version of the submodule by using `git pull` in the `z_framework` directory.
-2. Open the Z-Admin panel by opening the web page in your browser `yourwebsite.tld/[root/]z/` and log in.
+2. Open the [Z-Admin panel](../z-admin/usage.md) by opening the web page in your browser `yourwebsite.tld/[root/]z/` and log in.
 3. Go to the `Framework Update` page.
 4. Click `Update to framework version`.
 

--- a/docs/setup/installation.md
+++ b/docs/setup/installation.md
@@ -1,11 +1,11 @@
 # Installation
-ZubZet ships as a Composer package. New projects start from the **`zubzet/zubzet`** skeleton, which pulls in the framework and bundles a Docker development stack: Apache + PHP, MariaDB,
+ZubZet ships as a Composer package. New projects start from the [**`zubzet/zubzet`**](https://github.com/zubzet/zubzet) skeleton, which pulls in the framework and bundles a Docker development stack: Apache + PHP, MariaDB,
 phpMyAdmin, and a mail catcher.
 
 ## Prerequisites
-- **Docker** and **Docker Compose**
-- **Composer**
-- **Node.js** and **npm**
+- [**Docker**](https://docs.docker.com/get-started/get-docker/) and [**Docker Compose**](https://docs.docker.com/compose/)
+- [**Composer**](https://getcomposer.org/)
+- [**Node.js**](https://nodejs.org/en) and **npm**
 
 PHP itself is not required on your host as it runs inside the application container.
 

--- a/docs/setup/upgrade/1.2.0-to-1.3.0.md
+++ b/docs/setup/upgrade/1.2.0-to-1.3.0.md
@@ -29,7 +29,7 @@ applies it for you:
 * A view's `body` closure becomes `@section("content")`.
 * A view's `head` closure becomes `@section("head")`.
 * Every view starts with `@extends($layout)`, so the view plugs into the layout the controller chose.
-* Layouts drop their `$body($opt)` / `$head($opt)` calls in favor of `@yield("content")` /
+* [Layouts](../../core-features/layouts.md) drop their `$body($opt)` / `$head($opt)` calls in favor of `@yield("content")` /
   `@yield("head")`, and the framework essentials become the `<x-zubzet::head :opt="$opt"/>` and
   `<x-zubzet::body :opt="$opt"/>` components.
 

--- a/docs/template-rendering-usages/sending-an-email.md
+++ b/docs/template-rendering-usages/sending-an-email.md
@@ -1,8 +1,8 @@
 # Sending an email
-To send an email there are two methods in response called `sendEmail()` and `sendEmailToUser()`.
+To [send an email](../guides/email.md) there are two methods in [response](../api/classes/ZubZet-Framework-Message-Response.html) called `sendEmail()` and `sendEmailToUser()`.
 
 `$subject` can be an array to serve subjects for multiple languages.
-`$document` is the path to a view. Any view can be used as a mail. But it is wise to create extra ones, because script stuff won't work. Be careful not to leak data that only the requested account has access to.
+`$document` is the path to a [view](../core-features/views.md). Any view can be used as a mail. But it is wise to create extra ones, because script stuff won't work. Be careful not to leak data that only the requested account has access to.
 `$opt` are parameters to pass into the view. 
 
 This method uses `render()` internally.

--- a/docs/z-admin/login-as-another-user.md
+++ b/docs/z-admin/login-as-another-user.md
@@ -1,7 +1,7 @@
 # Login: Login as another user
-When logging in, the client exchanges it's identifier and password for a authentication token and logs in using this token from that point on. `$res->loginAs` allows you to login a current client as another user by their ```z_user.`id` ```. 
+When logging in, the client exchanges it's identifier and password for a authentication token and logs in using this token from that point on. [`$res->loginAs`](../api/classes/ZubZet-Framework-Message-Response.html#method_loginAs) allows you to login a current client as another user by their ```z_user.`id` ```. 
 
-The authentication token will track the exec user though. using this data, you'll always know who was logged in as who. You can also set an exec_user yourself, using the second argument of loginAs. If you don't want to build the tracking yourself, just use `Log / Statistics` within the z_admin panel. You are also able to login as another user using the very same panel.
+The authentication token will track the exec user though. using this data, you'll always know who was logged in as who. You can also set an exec_user yourself, using the second argument of loginAs. If you don't want to build the tracking yourself, just use `Log / Statistics` within the [z_admin panel](usage.md). You are also able to login as another user using the very same panel.
 
 Example:
 ```php

--- a/docs/z-admin/usage.md
+++ b/docs/z-admin/usage.md
@@ -2,7 +2,7 @@
 The Z-Admin panel is a management panel you can open to edit/create users or roles/permissions.
 
 # Using the Z-Admin panel
-The Z-Admin panel is a control panel all projects using the framework have. It is accessible with the z controller. For example, an URL like this: `localhost/project/z` or `abcde.de/z` or `{yourdomain.tld}/{yourwebsite}/z`. Only logged in accounts with the correct permissions are able to see this section.
+The Z-Admin panel is a control panel all projects using the framework have. It is accessible with the z controller. For example, an URL like this: `localhost/project/z` or `abcde.de/z` or `{yourdomain.tld}/{yourwebsite}/z`. Only logged in accounts with the correct [permissions](../core-features/permission-system.md) are able to see this section.
 
 ## Categories
 It has following categories:
@@ -10,8 +10,8 @@ It has following categories:
 | Category | Function |
 | -------- | -------- |
 | Instance | Simple place to change instance settings|
-| Log / Statistics | View logs and statistics
-| Framework Update | Start updates for the framework |
+| Log / Statistics | View [logs](../core-features/logging.md) and statistics
+| Framework Update | Start [updates for the framework](../setup/how-to-update.md) |
 | Edit User | Form to edit users
 | Add User | Form to add users
 | Roles | User permission managment |
@@ -29,7 +29,7 @@ To be able to use all functions, the following permissions are needed:
 - admin.roles.edit
 - admin.roles.delete
 - admin.log
-- admin.su
+- [admin.su](login-as-another-user.md)
 
 ## Assigning roles
 In order to assign any roles, you must go to Edit Users and select the user you want to give a role to. Hit the ‘+’ under the title ‘Roles’ and select the role the user should get.


### PR DESCRIPTION
Enriches the documentation with verified links and closes two gaps the pass surfaced.

**docs(links)** adds 154 links across 43 pages:
- internal cross-links between related pages (source-relative `.md`, mkdocs-validated)
- deep links into the phpdoc API reference (`../api/classes/...`, method anchors included)
- external references (PHP manual, MDN, Monolog, Doctrine DBAL, OWASP, RFC 9106, Docker/Composer/Node)

**docs(helpers)** documents the `e()` escaping helper in Global Helper Functions (null-safe signature, strip_tags + render-engine escaping, matching `{{ }}`) and links the mention in the views page to it.

**docs(frontend)** names the bundled Z.js script on the pages that use its API (auto form validation, CED, backend requests, presets), including where it is served (asset proxy) and that the default head component includes it automatically.

Verification: every added link was checked programmatically. Internal targets and anchors resolve against the source tree, every API path exists in the live phpdoc search index and returns 200, externals return 200. A link-syntax-stripped diff confirms no prose or code blocks were altered beyond wrapping existing words (plus two short "See also" sections). `mkdocs build` produces no new warnings.

https://claude.ai/code/session_01Jmsj4Yw5NuWU7smxjpYbUS